### PR TITLE
Improving VCF parsing

### DIFF
--- a/mutacc/cli/export.py
+++ b/mutacc/cli/export.py
@@ -10,7 +10,7 @@ import click
 from mutacc.parse.path_parse import make_dir
 from mutacc.mutaccDB.query import mutacc_query
 from mutacc.builds.build_dataset import MakeSet
-from mutacc.utils.vcf_writer import vcf_writer, append_gt
+from mutacc.utils.vcf_writer import vcf_writer
 from mutacc.parse.path_parse import parse_path
 from mutacc.utils.sort_variants import sort_variants
 
@@ -60,6 +60,7 @@ def export(context,
 
     sample_name = sample_name or member
 
+    #Info to be dumped into file
     query = (samples, regions, variants, sample_name)
 
     out_dir = out_dir or context.obj.get('query_dir')
@@ -75,25 +76,13 @@ def export(context,
     LOG.info("Query stored in {}".format(pickle_file))
 
     #sort variants
-    found_variants = {str(variant['_id']): variant for variant in variants}
-
-    all_variants = adapter.find_variants({})
-    all_variants = sort_variants(all_variants)
+    found_variants = sort_variants(variants)
 
     #WRITE VCF FILE
-    if merge_vcf:
-        vcf_file = parse_path(merge_vcf)
-        LOG.info("appending genotype field for {} in {}".format(
-            sample_name,
-            str(vcf_file)
-            )
-        )
-        append_gt(all_variants, found_variants, vcf_file, sample_name)
-    else:
 
-        vcf_dir = vcf_dir or context.obj.get('vcf_dir')
-        vcf_dir = make_dir(vcf_dir)
-        vcf_file = vcf_dir.joinpath("synthetic_{}.vcf".format(sample_name))
-        LOG.info("creating vcf file {}".format(str(vcf_file)))
+    vcf_dir = vcf_dir or context.obj.get('vcf_dir')
+    vcf_dir = make_dir(vcf_dir)
+    vcf_file = vcf_dir.joinpath("synthetic_{}.vcf".format(sample_name))
+    LOG.info("creating vcf file {}".format(str(vcf_file)))
 
-        vcf_writer(all_variants, found_variants, vcf_file, sample_name)
+    vcf_writer(found_variants, vcf_file, sample_name)

--- a/mutacc/cli/synthesize.py
+++ b/mutacc/cli/synthesize.py
@@ -10,7 +10,6 @@ import click
 from mutacc.parse.path_parse import make_dir
 from mutacc.mutaccDB.query import mutacc_query
 from mutacc.builds.build_dataset import MakeSet
-from mutacc.utils.vcf_writer import vcf_writer, append_gt
 from mutacc.parse.path_parse import parse_path
 from mutacc.utils.sort_variants import sort_variants
 

--- a/mutacc/utils/vcf_writer.py
+++ b/mutacc/utils/vcf_writer.py
@@ -3,68 +3,17 @@ import logging
 
 LOG = logging.getLogger(__name__)
 
-def vcf_writer(variants, found_variants, vcf_path, member):
+def vcf_writer(found_variants, vcf_path, member):
 
     with open(vcf_path, "w") as vcf_handle:
 
         vcf_handle.write("##fileformat=VCFv4.2\n")
         vcf_handle.write("#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\t{}\n".format(member))
 
-        for variant in variants:
+        for variant in found_variants:
 
-            found = found_variants.get(str(variant['_id']))
-            if found:
-                genotype = found.get("genotype") or './.'
-            else:
-                genotype = './.'
+            genotype = variant.get("genotype") or './.'
 
             vcf_entry = variant["vcf_entry"].strip("\n").split("\t")
             entry = "\t".join(vcf_entry[0:8] + ["GT"] + [genotype]) + "\n"
             vcf_handle.write(entry)
-
-def append_gt(variants, found_variants, vcf_path, member):
-    vcf_dir = vcf_path.parent
-    vcf_name = vcf_path.stem + "_{}.vcf".format(member)
-    out_path = vcf_dir.joinpath(vcf_name)
-
-    with open(vcf_path, "r") as in_vcf:
-
-        with open(out_path, "w") as out_vcf:
-            variant_num = 0
-            for old_entry in in_vcf:
-
-                entry = old_entry.strip('\n')
-
-                if entry.startswith("##"):
-
-                    pass
-
-                elif entry.startswith("#"):
-
-                    entry = entry + "\t" + member
-
-                else:
-
-                    try:
-                        variant = variants[variant_num]
-
-                    except IndexError:
-                        LOG.critical("list index out of range")
-                        raise
-
-                    found = found_variants.get(str(variant['_id']))
-
-                    if found:
-
-                        genotype = found.get("genotype") or './.'
-
-                    else:
-
-                        genotype = './.'
-
-                    entry = entry + "\t" + genotype
-                    variant_num += 1
-
-                entry = entry + "\n"
-
-                out_vcf.write(entry)

--- a/tests/utils/test_vcf_writer.py
+++ b/tests/utils/test_vcf_writer.py
@@ -1,7 +1,7 @@
 import pytest
 from pathlib import Path
 
-from mutacc.utils.vcf_writer import vcf_writer, append_gt
+from mutacc.utils.vcf_writer import vcf_writer
 
 VARIANT1 = {
     "vcf_entry": "4\t65071643\t.\tT\t<INV>\t100\tPASS\tSOMATIC;SVTYPE=INV\tGT\t./.",
@@ -15,14 +15,13 @@ VARIANT2 = {
 }
 VARIANTS = [VARIANT1, VARIANT2]
 
-FOUND_VARIANTS = {"123": VARIANT2}
 
 def test_vcf_writer(tmpdir):
 
     out_path = Path(tmpdir.mkdir("test_vcf_writer"))
     out_vcf = out_path.joinpath("test_vcf_father.vcf")
 
-    vcf_writer(VARIANTS, FOUND_VARIANTS, out_vcf, "father")
+    vcf_writer(VARIANTS, out_vcf, "father")
 
     with open(out_vcf, "r") as handle:
 
@@ -38,28 +37,3 @@ def test_vcf_writer(tmpdir):
             count += 1
 
         assert count == 4
-
-    append_gt(VARIANTS, FOUND_VARIANTS, out_vcf, "child")
-
-    assert out_path.joinpath("test_vcf_father_child.vcf").exists()
-
-    with open(out_path.joinpath("test_vcf_father_child.vcf"), "r") as handle:
-
-        count = 0
-        for line in handle:
-            if count == 0:
-                assert line.startswith("##")
-            elif count == 1:
-                assert line.startswith("#")
-                assert len(line.split("\t")) == 11
-            else:
-                assert len(line.split("\t")) == 11
-            count += 1
-
-        assert count == 4
-
-    assert out_path.joinpath("test_vcf_father_child.vcf").exists()
-
-    with pytest.raises(IndexError) as error:
-
-        append_gt([VARIANT1], FOUND_VARIANTS, out_vcf, "mother")


### PR DESCRIPTION
Improving how variants from vcf is parsed
(mutacc/builds/build_variant.py).

Also improves the vcf writing module (mutacc/utils/vcf_writer.py). I
have removed the support for merging vcf files, as I think this
is made better by using other tools (e.g 'bcftools merge ...').

