### PR TITLE
change location of directories and files generated by mutacc

### DIFF
--- a/mutacc/builds/build_dataset.py
+++ b/mutacc/builds/build_dataset.py
@@ -30,7 +30,7 @@ class MakeSet():
         self.samples = samples
         self.regions = regions
 
-    def exclude_from_background(self, out_dir, background, member):
+    def exclude_from_background(self, tmp_dir, background, member):
 
         """
             for each background fastq file exclude the reads overlapping with
@@ -38,13 +38,12 @@ class MakeSet():
              writing new fastq files excluding these reads.
 
             Args:
-                out_dir (str): path to directory where bam file is written
+                tmp_dir (str): path to directory where fastq_files with excluded
+                               reads, i.e. the 'background' reads.
                 backgrounds (list): list of paths to the 'background' bam files
                 member (str): synthetic family member for synthetic dataset.
                     choices: 'child', 'father', 'mother', 'affected'
         """
-        #Multiprocess in future?
-        out_dir = parse_path(out_dir, file_type = 'dir')
 
         bam_file = parse_path(background["bam_file"])
         fastq_files = [parse_path(fastq) for fastq in background["fastq_files"]]
@@ -61,13 +60,13 @@ class MakeSet():
                 )
             )
 
-            name_file = bam_handle.make_names_temp(out_dir)
+            name_file = bam_handle.make_names_temp(tmp_dir)
             self.excluded_backgrounds = []
             for fastq_file in fastq_files:
 
                 fastq_path = str(fastq_file)
                 out_name = str(member) + "_" + str(fastq_file.name)
-                out_path = str(out_dir.joinpath(out_name))
+                out_path = str(tmp_dir.joinpath(out_name))
 
                 #Here command line tool seqkit grep is used
                 exclude_from_fastq(name_file, out_path, fastq_path)

--- a/mutacc/cli/export.py
+++ b/mutacc/cli/export.py
@@ -24,9 +24,7 @@ LOG = logging.getLogger(__name__)
               default = 'affected')
 @click.option('-s','--sex',
               type = click.Choice(['male','female']))
-@click.option('--out-dir', type = click.Path())
-@click.option('--vcf-dir', type = click.Path())
-@click.option('--merge-vcf', type = click.Path())
+@click.option('--vcf-dir', type = click.Path(exists=True))
 @click.option('-p', '--proband', is_flag = True)
 @click.option('-n', '--sample-name')
 @click.pass_context
@@ -35,9 +33,7 @@ def export(context,
            variant_query,
            member,
            sex,
-           out_dir,
            vcf_dir,
-           merge_vcf,
            proband,
            sample_name):
 
@@ -63,11 +59,10 @@ def export(context,
     #Info to be dumped into file
     query = (samples, regions, variants, sample_name)
 
-    out_dir = out_dir or context.obj.get('query_dir')
-    out_dir = make_dir(out_dir)
+    query_dir = context.obj.get('query_dir')
 
     #pickle query
-    pickle_file = out_dir.joinpath(sample_name + "_query.mutacc")
+    pickle_file = query_dir.joinpath(sample_name + "_query.mutacc")
 
     with open(pickle_file, "wb") as pickle_handle:
 
@@ -79,10 +74,8 @@ def export(context,
     found_variants = sort_variants(variants)
 
     #WRITE VCF FILE
-
     vcf_dir = vcf_dir or context.obj.get('vcf_dir')
     vcf_dir = make_dir(vcf_dir)
-    vcf_file = vcf_dir.joinpath("synthetic_{}.vcf".format(sample_name))
+    vcf_file = vcf_dir.joinpath("{}_variants.vcf".format(sample_name))
     LOG.info("creating vcf file {}".format(str(vcf_file)))
-
     vcf_writer(found_variants, vcf_file, sample_name)

--- a/mutacc/cli/extract.py
+++ b/mutacc/cli/extract.py
@@ -19,31 +19,27 @@ LOG = logging.getLogger(__name__)
               type = click.Path(exists = True),
               help = " .yaml file for case. See README.md for information on what to include or example .yaml file in data/data.yaml")
 @click.option('--padding', default = 300)
-@click.option('--mutacc-dir', type=click.Path())
-@click.option('-o', '--out-dir', type=click.Path())
 @click.pass_context
-def extract_command(context, case, padding, mutacc_dir, out_dir):
+def extract_command(context, case, padding):
 
     """
         extract reads from case
     """
     LOG.info("extracting reads from case {0}".format(case))
 
-    mutacc_dir = mutacc_dir or context.obj.get('mutacc_dir')
-    mutacc_dir = make_dir(mutacc_dir)
+    read_dir = context.obj.get('read_dir')
 
     case = yaml_parse(case)
 
     case = CompleteCase(case)
 
     case.get_variants(padding = padding)
-    case.get_samples(mutacc_dir)
+    case.get_samples(read_dir)
     case.get_case()
 
-    out_dir = out_dir or context.obj.get('case_dir')
-    out_dir = make_dir(out_dir)
+    import_dir = context.obj.get('import_dir')
 
-    pickle_file = out_dir.joinpath(case.case_id + "_case"+ ".mutacc")
+    pickle_file = import_dir.joinpath(case.case_id + "_import"+ ".mutacc")
 
     #Serialize case object to file for later import
     with open(pickle_file, "wb") as pickle_handle:

--- a/mutacc/cli/root_dirs.py
+++ b/mutacc/cli/root_dirs.py
@@ -1,0 +1,44 @@
+#Names of directories placed under the root-dir given by the user
+#The root dir is specified using the --root-dir option or
+#in the config file
+
+
+SUB_DIRS = {
+
+    #Subdirectory for the extracted reads from the cases
+    #Here all reads will be stored according to
+    #  reads
+    #      |
+    #      case1
+    #      |   |
+    #      |   sample1
+    #      |   |     |
+    #      |   |     fastq_files
+    #      |   sample2
+    #      |   |     |
+    #      |   |     fastq_files
+    #      |   sample2
+    #      |         |
+    #      |         fastq_files
+    #      case2
+    #      ...
+    'read_dir': 'reads',
+
+    #Subdirectory for vcfs, containing the exported variants
+    'vcf_dir': 'variants',
+
+    #Subdirectory for cases to be imported
+    'import_dir': 'imports',
+
+    #Subdirectory for queries
+    'query_dir': 'queries',
+
+    #Subdirectory for synthetic datasets
+    'dataset_dir': 'datasets',
+
+    #Subdirectory for temp files such as
+    #the files containing read_IDs for search in fastq files
+    #and the fastq_files with some excluded reads.
+    'temp_dir': 'temporaries'
+
+}

--- a/mutacc/cli/synthesize.py
+++ b/mutacc/cli/synthesize.py
@@ -1,10 +1,7 @@
 
 import logging
 import yaml
-import tempfile
 import pickle
-from shutil import rmtree
-
 import click
 
 from mutacc.parse.path_parse import make_dir
@@ -23,16 +20,14 @@ LOG = logging.getLogger(__name__)
 @click.option('-b','--background-bam', type = click.Path())
 @click.option('-f','--background-fastq', type = click.Path())
 @click.option('-f2','--background-fastq2', type = click.Path())
-@click.option('--out-dir', type = click.Path())
-@click.option('--tmp-dir', type = click.Path())
+@click.option('--dataset-dir', type = click.Path())
 @click.option('-q', '--query', type = click.Path(exists=True))
 @click.option('-s', '--save-background', is_flag = True)
 def synthesize_command(context,
                        background_bam,
                        background_fastq,
                        background_fastq2,
-                       out_dir,
-                       tmp_dir,
+                       dataset_dir,
                        query,
                        save_background):
 
@@ -65,12 +60,11 @@ def synthesize_command(context,
     #Create temporary directory
     #tmp_dir = tempfile.mkdtemp("_mutacc_tmp")
 
-    tmp_dir = tmp_dir or context.obj.get('tmp_dir')
-    tmp_dir = make_dir(tmp_dir)
+    temp_dir = context.obj.get('temp_dir')
 
-    LOG.info("Temporay files stored in {}".format(tmp_dir))
+    LOG.info("Temporay files stored in {}".format(temp_dir))
 
-    make_set.exclude_from_background(out_dir = tmp_dir,
+    make_set.exclude_from_background(tmp_dir = temp_dir,
                                      background = background,
                                      member = sample_name)
 
@@ -78,15 +72,13 @@ def synthesize_command(context,
     #Merge the background files with excluded reads with the bam Files
     #Holding the reads for the regions of the variants to be included in
     #validation set
-    out_dir = out_dir or context.obj.get('dataset_dir')
-    out_dir = make_dir(out_dir)
+    dataset_dir = dataset_dir or context.obj.get('dataset_dir')
+    dataset_dir = make_dir(dataset_dir)
     synthetics = make_set.merge_fastqs(
-            out_dir = out_dir,
+            out_dir = dataset_dir,
             save_background = save_background
         )
 
-    #Remove temporary directory
-    #rmtree(temp_dir)
 
     for synthetic in synthetics:
         LOG.info("Synthetic datasets created in {}".format(synthetic))

--- a/tests/builds/test_build_dataset.py
+++ b/tests/builds/test_build_dataset.py
@@ -22,7 +22,7 @@ def test_MakeSet(mock_adapter, tmpdir):
                   "fastq_files": [FASTQ1, FASTQ2]}
 
     temp_dir = Path(str(tmpdir.mkdir("export_tmp_test")))
-    make_set.exclude_from_background(out_dir = temp_dir,
+    make_set.exclude_from_background(tmp_dir = temp_dir,
                                      background = background,
                                      member = 'affected')
 

--- a/tests/cli/test_export.py
+++ b/tests/cli/test_export.py
@@ -4,10 +4,13 @@ from click.testing import CliRunner
 
 from mutacc.cli.root import cli
 
-def test_export():
+def test_export(tmpdir):
+
+    root_dir = str(tmpdir.mkdir("mutacc_root_test"))
 
     runner = CliRunner()
     result = runner.invoke(cli, [
+            '--root-dir', root_dir,
             'db',
             'export',
             '--help'

--- a/tests/cli/test_extract.py
+++ b/tests/cli/test_extract.py
@@ -12,14 +12,12 @@ CONFIG_PATH = "tests/fixtures/config.yaml"
 
 def test_extract(tmpdir):
 
-    mutacc_dir = str(tmpdir.mkdir("mutacc_reads_test"))
-    case_dir = str(tmpdir.mkdir("mutacc_cases_test"))
+    root_dir = str(tmpdir.mkdir("mutacc_root_test"))
 
     runner = CliRunner()
     result = runner.invoke(cli, [
+            '--root-dir', root_dir,
             'extract',
-            '--mutacc-dir', mutacc_dir,
-            '--out-dir', case_dir,
             '--padding', '1500',
             '--case', CASE_PATH
         ]
@@ -29,34 +27,20 @@ def test_extract(tmpdir):
 
     for i in [1,2,3]:
 
-        assert Path(mutacc_dir).joinpath(
-            "12345/{}/mutacc_reduced_ref_4_1000000_10002000.bam".format(
+        assert Path(root_dir).joinpath(
+            "reads/12345/{}/mutacc_reduced_ref_4_1000000_10002000.bam".format(
                     i
                 )
             ).exists()
 
-        assert Path(mutacc_dir).joinpath(
-            "12345/{}/mutacc_reduced_ref_4_1000000_10002000_R1.fastq.gz".format(
+        assert Path(root_dir).joinpath(
+            "reads/12345/{}/mutacc_reduced_ref_4_1000000_10002000_R1.fastq.gz".format(
                     i
                 )
             ).exists()
 
-        assert Path(mutacc_dir).joinpath(
-            "12345/{}/mutacc_reduced_ref_4_1000000_10002000_R2.fastq.gz".format(
+        assert Path(root_dir).joinpath(
+            "reads/12345/{}/mutacc_reduced_ref_4_1000000_10002000_R2.fastq.gz".format(
                     i
                 )
             ).exists()
-
-    #Test with config file
-    runner = CliRunner()
-    result = runner.invoke(cli, [
-            '--config-file', CONFIG_PATH,
-            'extract',
-            '--mutacc-dir', mutacc_dir,
-            '--out-dir', case_dir,
-            '--padding', '1500',
-            '--case', CASE_PATH
-        ]
-    )
-
-    assert result.exit_code == 0

--- a/tests/cli/test_remove.py
+++ b/tests/cli/test_remove.py
@@ -4,10 +4,13 @@ from click.testing import CliRunner
 
 from mutacc.cli.root import cli
 
-def test_remove():
+def test_remove(tmpdir):
+
+    root_dir = str(tmpdir.mkdir("mutacc_root_test"))
 
     runner = CliRunner()
     result = runner.invoke(cli, [
+            '--root-dir', root_dir,
             'db',
             'remove',
             '--help'


### PR DESCRIPTION
Mutacc now takes a 'root_dir' specified by the user through the option
--rot-dir, or in the config file 'root_dir: ...'. All necessary
subdirectories will be created under this root directory (see
mutacc/cli/root_dirs.py).