### PR TITLE
Version

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ is to get an actual padding of 1000 bp around the variant region.
 - fastq-reads gets versioned by time of creation
 - added a demo option
 - .github dir with CODEOWNERS and PULL_REQUEST_TEMPLATE
+- version command, taking a directory as input, version dataset and loads it to database
 
 ### Fixed
 

--- a/mutacc/builds/build_version.py
+++ b/mutacc/builds/build_version.py
@@ -17,6 +17,15 @@ class VersionedDataset(dict):
 
     def __init__(self, dataset_dir, comment=None, md5=False):
 
+        """
+            Instatiate a versioned dataset
+
+            Args:
+                dataset_dir (Path): Path to directory where dataset files are found
+                comment (str): optional comment to dataset
+                md5 (bool): If true, the md5 hash of files will be calculated
+        """
+
         super(VersionedDataset, self).__init__()
 
         self.dataset_dir = Path(dataset_dir)
@@ -118,11 +127,3 @@ class VersionedDataset(dict):
             raise FileNotFoundError
 
         return self.dataset_dir.joinpath(vcf_file)
-
-
-if __name__ == '__main__':
-
-    dataset = VersionedDataset(dataset_dir='/Users/adam.rosenbaum/DATASET', comment='TESTTT', md5=True)
-
-    print(dataset['samples'])
-    print(dataset)

--- a/mutacc/builds/build_version.py
+++ b/mutacc/builds/build_version.py
@@ -3,127 +3,79 @@ import os
 from pathlib import Path
 import datetime
 
+
 import ped_parser
 
 from mutacc.subprocessing.get_md5 import get_md5
+from mutacc.parse.path_parse import parse_path, list_files, list_dirs
+from mutacc.parse.parse_ped import parse_ped
+
 
 LOG = logging.getLogger(__name__)
 
+
 class VersionedDataset(dict):
 
-    """
-        Versioned dataset
-    """
-
-    def __init__(self, dataset_dir, comment=None, md5=False):
-
-        """
-            Instatiate a versioned dataset
-
-            Args:
-                dataset_dir (Path): Path to directory where dataset files are found
-                comment (str): optional comment to dataset
-                md5 (bool): If true, the md5 hash of files will be calculated
-        """
+    def __init__(self, dataset_dir):
 
         super(VersionedDataset, self).__init__()
+        self.dataset_dir = parse_path(dataset_dir, file_type='dir')
 
-        self.dataset_dir = Path(dataset_dir)
-        self.md5 = md5
+    def build_dataset(self, md5=False, comment=None):
 
-        self._build_samples()
-        vcf_file = self._find_vcf()
-        self['vcf'] = {'path': str(vcf_file),
-                       'md5': get_md5(vcf_file) if self.md5 else None}
+        ped_file = self._find_file(self.dataset_dir, '.ped')
+        family = self._parse_ped(ped_file)
+
+        self['dataset_id'] = family['family_id']
+        self['samples'] = list()
+
+        for sample in family['samples']:
+            sample_id = sample['sample_id']
+            sample_dir = self.find_sample_dir(sample_id)
+            sample_files = list_files(sample_dir)
+            files = [{'path': str(file),
+                      'md5': self._get_md5(file) if md5 else None}
+                     for file in sample_files]
+
+            self['samples'].append(
+                {'sample_id': sample_id,
+                 'mother': sample['mother'],
+                 'father': sample['father'],
+                 'files': files}
+            )
+
+        vcf_path = self._find_file(self.dataset_dir, '.vcf')
+        self['vcf'] = {'path': str(vcf_path), 'md5': self._get_md5(vcf_path)}
 
         if comment is not None:
             self['comment'] = comment
 
-        self['created'] = datetime.datetime.utcnow()
+    def find_sample_dir(self, sample_id):
 
-    def _build_samples(self, md5=False):
+        for dir in list_dirs(self.dataset_dir):
+            if str(dir).split('/')[-1] == sample_id:
+                return dir
 
-        family_name, family_obj = self._parse_pedigree()
+        log_msg = f"directory {sample_id} not found"
+        LOG.warning(log_msg)
+        raise FileNotFoundError
 
-        self['dataset_id'] = family_name
-        self['samples'] = []
+    @staticmethod
+    def _find_file(dir_path, includes):
+        for file in list_files(dir_path):
+            if includes in str(file).split('/')[-1]:
+                return file
 
-        for sample_id, sample in family_obj.individuals.items():
+        log_msg = f"File with '{includes}' not found"
+        LOG.warning(log_msg)
+        raise FileNotFoundError
 
-            sample_obj = {}
-            sample_obj['sample_id'] = sample_id
-            sample_obj['mother'] = sample.mother
-            sample_obj['father'] = sample.father
-
-            fastq_files = self._find_sample_fastqs(sample_id)
-            sample_obj['fastq'] = [{'path': str(fastq),
-                                    'md5': get_md5(fastq) if self.md5 else None}
-                                   for fastq in fastq_files]
-
-            self['samples'].append(sample_obj)
-
-    def _parse_pedigree(self):
-
-        ped_file = self._find_ped_file()
-
-        with open(ped_file, 'r') as ped_handle:
-            ped_obj = ped_parser.FamilyParser(ped_handle)
-
-        family_name, family_obj = list(ped_obj.families.items())[0]
-        sample_names = list(family_obj.individuals.keys())
-
-        self['samples'] = [{'sample_id': sample_id} for sample_id in sample_names]
+    @staticmethod
+    def _parse_ped(ped_file):
+        family = parse_ped(ped_file)
+        return family
 
 
-        return family_name, family_obj
-
-    def _find_ped_file(self):
-
-        ped_file = None
-        for file in os.listdir(self.dataset_dir):
-            if file.endswith('.ped'):
-                ped_file = file
-
-        if ped_file is None:
-            LOG.warning('pedigree file not found in dir')
-            raise FileNotFoundError
-
-        return self.dataset_dir.joinpath(ped_file)
-
-    def _find_sample_fastqs(self, sample_id):
-
-        sample_dir = None
-
-        for file in os.listdir(self.dataset_dir):
-            if file == sample_id:
-                if self.dataset_dir.joinpath(file).is_dir():
-                    sample_dir = self.dataset_dir.joinpath(file)
-                    break
-
-        if sample_dir is None:
-            log_msg = f"No directory found with name {sample_id}"
-            LOG.warning(log_msg)
-            raise FileNotFoundError
-
-        fastq_files = []
-
-        for file in os.listdir(sample_dir):
-            if '.fastq' in file:
-                fastq_files.append(sample_dir.joinpath(file))
-
-
-        return fastq_files
-
-
-    def _find_vcf(self):
-
-        vcf_file = None
-        for file in os.listdir(self.dataset_dir):
-            if '.vcf' in file:
-                vcf_file = file
-
-        if vcf_file is None:
-            LOG.warning('vcf file not found in dir')
-            raise FileNotFoundError
-
-        return self.dataset_dir.joinpath(vcf_file)
+    @staticmethod
+    def _get_md5(file_path):
+        return get_md5(file_path)

--- a/mutacc/builds/build_version.py
+++ b/mutacc/builds/build_version.py
@@ -1,0 +1,128 @@
+import logging
+import os
+from pathlib import Path
+import datetime
+
+import ped_parser
+
+from mutacc.subprocessing.get_md5 import get_md5
+
+LOG = logging.getLogger(__name__)
+
+class VersionedDataset(dict):
+
+    """
+        Versioned dataset
+    """
+
+    def __init__(self, dataset_dir, comment=None, md5=False):
+
+        super(VersionedDataset, self).__init__()
+
+        self.dataset_dir = Path(dataset_dir)
+        self.md5 = md5
+
+        self._build_samples()
+        vcf_file = self._find_vcf()
+        self['vcf'] = {'path': str(vcf_file),
+                       'md5': get_md5(vcf_file) if self.md5 else None}
+
+        if comment is not None:
+            self['comment'] = comment
+
+        self['created'] = datetime.datetime.utcnow()
+
+    def _build_samples(self, md5=False):
+
+        family_name, family_obj = self._parse_pedigree()
+
+        self['dataset_id'] = family_name
+        self['samples'] = []
+
+        for sample_id, sample in family_obj.individuals.items():
+
+            sample_obj = {}
+            sample_obj['sample_id'] = sample_id
+            sample_obj['mother'] = sample.mother
+            sample_obj['father'] = sample.father
+
+            fastq_files = self._find_sample_fastqs(sample_id)
+            sample_obj['fastq'] = [{'path': str(fastq),
+                                    'md5': get_md5(fastq) if self.md5 else None}
+                                   for fastq in fastq_files]
+
+            self['samples'].append(sample_obj)
+
+    def _parse_pedigree(self):
+
+        ped_file = self._find_ped_file()
+
+        with open(ped_file, 'r') as ped_handle:
+            ped_obj = ped_parser.FamilyParser(ped_handle)
+
+        family_name, family_obj = list(ped_obj.families.items())[0]
+        sample_names = list(family_obj.individuals.keys())
+
+        self['samples'] = [{'sample_id': sample_id} for sample_id in sample_names]
+
+
+        return family_name, family_obj
+
+    def _find_ped_file(self):
+
+        ped_file = None
+        for file in os.listdir(self.dataset_dir):
+            if file.endswith('.ped'):
+                ped_file = file
+
+        if ped_file is None:
+            LOG.warning('pedigree file not found in dir')
+            raise FileNotFoundError
+
+        return self.dataset_dir.joinpath(ped_file)
+
+    def _find_sample_fastqs(self, sample_id):
+
+        sample_dir = None
+
+        for file in os.listdir(self.dataset_dir):
+            if file == sample_id:
+                if self.dataset_dir.joinpath(file).is_dir():
+                    sample_dir = self.dataset_dir.joinpath(file)
+                    break
+
+        if sample_dir is None:
+            log_msg = f"No directory found with name {sample_id}"
+            LOG.warning(log_msg)
+            raise FileNotFoundError
+
+        fastq_files = []
+
+        for file in os.listdir(sample_dir):
+            if '.fastq' in file:
+                fastq_files.append(sample_dir.joinpath(file))
+
+
+        return fastq_files
+
+
+    def _find_vcf(self):
+
+        vcf_file = None
+        for file in os.listdir(self.dataset_dir):
+            if '.vcf' in file:
+                vcf_file = file
+
+        if vcf_file is None:
+            LOG.warning('vcf file not found in dir')
+            raise FileNotFoundError
+
+        return self.dataset_dir.joinpath(vcf_file)
+
+
+if __name__ == '__main__':
+
+    dataset = VersionedDataset(dataset_dir='/Users/adam.rosenbaum/DATASET', comment='TESTTT', md5=True)
+
+    print(dataset['samples'])
+    print(dataset)

--- a/mutacc/cli/database.py
+++ b/mutacc/cli/database.py
@@ -13,6 +13,7 @@ from .export import export as export_command
 from .importing import importing as import_command
 from .remove_command import remove_command as remove_command
 from .view_command import view_command as view_command
+from .version_command import version_command as version_command
 
 LOG = logging.getLogger(__name__)
 
@@ -53,3 +54,4 @@ database_group.add_command(export_command)
 database_group.add_command(import_command)
 database_group.add_command(remove_command)
 database_group.add_command(view_command)
+database_group.add_command(version_command)

--- a/mutacc/cli/version_command.py
+++ b/mutacc/cli/version_command.py
@@ -1,0 +1,38 @@
+import click
+import json
+from pprint import pprint
+import logging
+
+from mutacc.parse.path_parse import parse_path
+from mutacc.builds.build_version import VersionedDataset
+from mutacc.mutaccDB.insert import insert_version
+
+LOG = logging.getLogger(__name__)
+
+@click.command('version')
+@click.option('-d', '--dataset-dir',
+              type=click.Path(exists=True),
+              help="path to directory with dataset")
+@click.option('-m', '--md5',
+              is_flag=True,
+              help="Get md5 sum of files")
+@click.option('-c', '--comment',
+              type=str,
+              help="Additional comment")
+@click.pass_context
+def version_command(context, dataset_dir, md5, comment):
+    """
+        Version dataset and truth set
+    """
+
+    log_msg = f"Versioning dataset"
+    LOG.info(log_msg)
+
+    adapter = context.obj['adapter']
+
+    dataset_dir=parse_path(dataset_dir, file_type='dir')
+    dataset = VersionedDataset(dataset_dir=dataset_dir,
+                               comment=comment,
+                               md5=md5)
+
+    insert_version(adapter, dataset)

--- a/mutacc/cli/version_command.py
+++ b/mutacc/cli/version_command.py
@@ -31,8 +31,7 @@ def version_command(context, dataset_dir, md5, comment):
     adapter = context.obj['adapter']
 
     dataset_dir=parse_path(dataset_dir, file_type='dir')
-    dataset = VersionedDataset(dataset_dir=dataset_dir,
-                               comment=comment,
-                               md5=md5)
+    dataset = VersionedDataset(dataset_dir=dataset_dir)
+    dataset.build_dataset(md5=md5, comment=comment)
 
     insert_version(adapter, dataset)

--- a/mutacc/mutaccDB/db_adapter.py
+++ b/mutacc/mutaccDB/db_adapter.py
@@ -32,8 +32,16 @@ class MutaccAdapter(MongoAdapter):
 
             self.db.create_collection("cases")
 
+        if "datasets" not in self.db.list_collection_names():
+            self.db.create_collection("datasets")
+
         self.variants_collection = self.db.variants
         self.cases_collection = self.db.cases
+        self.datasets_collection = self.db.datasets
+
+    def add_dataset(self, dataset):
+        
+        self.datasets_collection.insert_one(dataset)
 
     def add_variants(self, variants):
         """

--- a/mutacc/mutaccDB/insert.py
+++ b/mutacc/mutaccDB/insert.py
@@ -51,3 +51,6 @@ def insert_entire_case(mutacc_adapter, case, replace=False):
     mutacc_adapter.add_case(case)
 
     LOG.info("Case added to mutaccDB")
+
+def insert_version(mutacc_adapter, dataset):
+    mutacc_adapter.add_dataset(dataset)

--- a/mutacc/parse/parse_ped.py
+++ b/mutacc/parse/parse_ped.py
@@ -1,0 +1,27 @@
+
+import ped_parser
+
+def parse_ped(ped_file) -> dict:
+
+    family = dict()
+
+    with open(ped_file, 'r') as ped_handle:
+        ped_obj = ped_parser.FamilyParser(ped_handle)
+
+    family_name, family_obj = list(ped_obj.families.items())[0]
+
+    family['family_id'] = family_name
+
+    samples = [
+        {
+            'sample_id': sample_id,
+            'mother': ind.mother,
+            'father': ind.father,
+            'affected': ind.affected,
+            'sex': ind.sex
+            }
+        for sample_id, ind in family_obj.individuals.items()
+    ]
+
+    family['samples'] = samples
+    return family

--- a/mutacc/parse/path_parse.py
+++ b/mutacc/parse/path_parse.py
@@ -1,4 +1,5 @@
 from pathlib import Path
+import os
 import gzip
 def parse_path(path, file_type: str  = 'file'):
 
@@ -44,3 +45,19 @@ def get_file_handle(file_name):
     else:
 
         return open(file_name, 'r')
+
+def list_files(directory):
+
+    directory_path = parse_path(directory, file_type='dir')
+    for file in os.listdir(directory_path):
+        file_path = directory_path.joinpath(file)
+        if file_path.is_file():
+            yield file_path
+
+def list_dirs(directory):
+
+    directory_path = parse_path(directory, file_type='dir')
+    for dir in os.listdir(directory_path):
+        dir_path = directory_path.joinpath(dir)
+        if dir_path.is_dir():
+            yield dir_path

--- a/mutacc/subprocessing/get_md5.py
+++ b/mutacc/subprocessing/get_md5.py
@@ -1,0 +1,33 @@
+import subprocess
+import logging
+from pathlib import Path
+
+LOG = logging.getLogger(__name__)
+
+def get_md5(file_path):
+    """
+        Use command line tool 'md5' to calculate md5 hash of file
+
+        Args:
+            file_path(str): absolute path to file
+        Returns:
+            md5_sum(str): md5 sum of file
+    """
+
+    md5_base = 'md5'
+
+    md5_cmd = [
+        md5_base,
+        '-q',
+        str(file_path)
+    ]
+
+    log_msg = f"finding md5sum for {file_path}"
+    LOG.info(log_msg)
+
+    md5_sum = subprocess.check_output(md5_cmd).decode().strip()
+
+    log_msg = f"md5sum: {md5_sum}"
+    LOG.info(log_msg)
+
+    return md5_sum

--- a/tests/builds/test_build_version.py
+++ b/tests/builds/test_build_version.py
@@ -1,0 +1,40 @@
+import pytest
+from unittest.mock import patch
+
+from pathlib import Path
+from mutacc.builds.build_version import VersionedDataset
+
+SAMPLE_IDS = ('sample_1', 'sample_2', 'sample_3')
+E_SAMPLE_ID = 'sample_4'
+
+def test_find_sample_dir(dataset_dir):
+
+    versioned_dataset = VersionedDataset(dataset_dir=dataset_dir)
+
+    for sample_id in SAMPLE_IDS:
+        dir = versioned_dataset.find_sample_dir(sample_id=sample_id)
+        assert dir.exists()
+
+    with pytest.raises(FileNotFoundError) as error:
+        dir = versioned_dataset.find_sample_dir(E_SAMPLE_ID)
+
+def test_find_file(dataset_dir):
+
+    versioned_dataset = VersionedDataset(dataset_dir=dataset_dir)
+    file = versioned_dataset._find_file(dir_path=dataset_dir, includes='.vcf')
+
+    assert file.exists
+
+    with pytest.raises(FileNotFoundError) as error:
+        file = versioned_dataset._find_file(dir_path=dataset_dir, includes=E_SAMPLE_ID)
+
+@patch('mutacc.builds.build_version.get_md5')
+def test_build_dataset(mock_md5, dataset_dir):
+
+    versioned_dataset = VersionedDataset(dataset_dir=dataset_dir)
+    assert not list(versioned_dataset.keys())
+    mock_md5.return_value = ''
+    versioned_dataset.build_dataset(md5=True)
+    assert set(versioned_dataset.keys()) == {'dataset_id', 'samples', 'vcf'}
+    versioned_dataset.build_dataset(md5=True, comment='comment')
+    assert set(versioned_dataset.keys()) == {'dataset_id', 'samples', 'vcf', 'comment'}

--- a/tests/cli/test_export.py
+++ b/tests/cli/test_export.py
@@ -8,8 +8,9 @@ from click.testing import CliRunner
 
 from mutacc.cli.root import cli
 
+@patch('mutacc.cli.database.mongo_adapter.get_client')
 @patch('mutacc.cli.database.MutaccAdapter')
-def test_export(mock_mutacc_adapter, mock_adapter, tmpdir):
+def test_export(mock_mutacc_adapter, mock_get_client, mock_adapter, tmpdir):
 
     """
         Test export command

--- a/tests/cli/test_version.py
+++ b/tests/cli/test_version.py
@@ -1,0 +1,36 @@
+"""
+    Test export command
+"""
+
+from unittest.mock import patch
+
+from click.testing import CliRunner
+
+from mutacc.cli.root import cli
+
+@patch('mutacc.cli.database.mongo_adapter.get_client')
+@patch('mutacc.cli.database.MutaccAdapter')
+@patch('mutacc.builds.build_version.get_md5')
+def test_export(mock_md5, mock_mutacc_adapter, mock_get_client, mock_adapter, dataset_dir, tmpdir):
+
+    """
+        Test export command
+    """
+
+    mock_mutacc_adapter.return_value = mock_adapter
+    mock_md5.return_value = 'md5hash'
+    root_dir = str(tmpdir.mkdir("mutacc_root_test"))
+
+    runner = CliRunner()
+    result = runner.invoke(cli, [
+        '--root-dir', root_dir,
+        'db',
+        'version',
+        '-d', dataset_dir,
+        '-c', 'comment',
+        '-m'
+        ])
+
+    assert result.exit_code == 0
+
+    

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -16,6 +16,8 @@ from mutacc.builds.build_case import Case
 from mutacc.mutaccDB.insert import insert_entire_case
 from .random_case import random_trio
 
+DATASET_DIR = "tests/fixtures/dataset/"
+PED_PATH = "tests/fixtures/dataset/dataset.ped"
 
 @pytest.fixture
 def read_ids_fixed():
@@ -131,3 +133,11 @@ def mock_real_adapter(tmpdir):
     insert_entire_case(adapter, case)
 
     return adapter
+
+@pytest.fixture
+def dataset_dir():
+    return  DATASET_DIR
+
+@pytest.fixture
+def ped_path():
+    return PED_PATH

--- a/tests/fixtures/dataset/dataset.ped
+++ b/tests/fixtures/dataset/dataset.ped
@@ -1,0 +1,4 @@
+#Family ID	Individual ID	Paternal ID	Maternal ID	Sex	Phenotype
+dataset	sample_1	0	0	1	1
+dataset	sample_2	sample_1	sample_3	1	2
+dataset	sample_3	0	0	2	1

--- a/tests/fixtures/dataset/sample_1/sample_1_1.fastq.gz
+++ b/tests/fixtures/dataset/sample_1/sample_1_1.fastq.gz
@@ -1,0 +1,1 @@
+dasdsahjdshdjsadsa

--- a/tests/fixtures/dataset/sample_1/sample_1_2.fastq.gz
+++ b/tests/fixtures/dataset/sample_1/sample_1_2.fastq.gz
@@ -1,0 +1,1 @@
+dasdsahjddsa

--- a/tests/fixtures/dataset/sample_2/sample_2_1.fastq.gz
+++ b/tests/fixtures/dataset/sample_2/sample_2_1.fastq.gz
@@ -1,0 +1,1 @@
+hgjuewchahjddsa

--- a/tests/fixtures/dataset/sample_2/sample_2_2.fastq.gz
+++ b/tests/fixtures/dataset/sample_2/sample_2_2.fastq.gz
@@ -1,0 +1,1 @@
+hgjuewchahdsa

--- a/tests/fixtures/dataset/sample_3/sample_3_1.fastq.gz
+++ b/tests/fixtures/dataset/sample_3/sample_3_1.fastq.gz
@@ -1,0 +1,1 @@
+hgjuewchahdsaooooooo

--- a/tests/fixtures/dataset/sample_3/sample_3_2.fastq.gz
+++ b/tests/fixtures/dataset/sample_3/sample_3_2.fastq.gz
@@ -1,0 +1,1 @@
+hgjuewchahdsaooooooohfd

--- a/tests/fixtures/dataset/test.vcf.gz
+++ b/tests/fixtures/dataset/test.vcf.gz
@@ -1,0 +1,1 @@
+hdasuhi87gh

--- a/tests/parse/test_parse_ped.py
+++ b/tests/parse/test_parse_ped.py
@@ -1,0 +1,9 @@
+import pytest
+
+from mutacc.parse.parse_ped import parse_ped
+
+def test_parse_ped(ped_path):
+
+    family = parse_ped(ped_path)
+    assert isinstance(family, dict)
+    


### PR DESCRIPTION
New functionality to version and store datasets generated by mutacc.

The path to a directory where the dataset and fastq files resides. This directory should include a .ped file of the dataset, the generated vcf file, and the fastq files for each sample in the dataset. If specified the md5 hash of the files will be calculated. The dataset with the accompanying fastq- and vcf files are then stored in the collection 'datasets' 