### PR TITLE
Get variant type (SV|SNV) from vcf

### DIFF
--- a/mutacc/builds/build_variant.py
+++ b/mutacc/builds/build_variant.py
@@ -62,13 +62,24 @@ class Variant(dict):
         #For variants with an ID 'SVTYPE' in the INFO field of the vcf entry
         start, end = self._find_start_end()
 
-        vtype = self.entry.INFO.get("TYPE") or self.entry.INFO.get("SVTYPE") or 'None'
-        vtype = vtype.upper()
-
         region = {"start": start - padding,
                   "end": end + padding}
 
-        return vtype, region
+        return region
+
+    def _find_type(self):
+
+        variant_type = None
+        variant_subtype = None
+
+        if self.entry.INFO.get('TYPE') is not None:
+            variant_type = 'SNV'
+            variant_subtype = self.entry.INFO['TYPE']
+        elif self.entry.INFO.get('SVTYPE') is not None:
+            variant_type = 'SV'
+            variant_subtype = self.entry.INFO['SVTYPE']
+
+        return variant_type, variant_subtype
 
     def _find_start_end(self):
         start = self.entry.start
@@ -128,12 +139,15 @@ class Variant(dict):
         """
 
         #Find genotype and sample id for the samples given in the vcf file
-        vtype, region = self._find_region(padding)
+        region = self._find_region(padding)
         samples = self._find_genotypes()
         genes = self._find_genes()
+        variant_type, variant_subtype = self._find_type()
+
 
         self['display_name'] = self.display_name
-        self['variant_type'] = vtype
+        self['variant_type'] = variant_type
+        self['variant_subtype'] = variant_subtype
         self['alt'] = self.entry.ALT
         self['ref'] = self.entry.REF
         self['chrom'] = self.entry.CHROM

--- a/mutacc/utils/vcf_writer.py
+++ b/mutacc/utils/vcf_writer.py
@@ -51,16 +51,16 @@ def vcf_writer(found_variants, vcf_path, sample_name):
             #Write info field
             info = ""
             info += f"END={variant['end']};"
-
             if variant.get('RankScore'):
                 info += f"MutaccRankScore={variant['RankScore']};"
             if variant.get('rank_model_version'):
                 info += f"RMV={variant['rank_model_version']};"
 
-            if variant['variant_type'].lower() in ('snp', 'snv', 'mnp', 'indel', 'complex'):
-                info += f"TYPE={variant['variant_type']}"
-            else:
-                info += f"SVTYPE={variant['variant_type']}"
+            if variant['variant_type'].upper() == 'SNV':
+                info += f"TYPE={variant['variant_subtype']}"
+            elif variant['variant_type'].upper() == 'SV':
+                info += f"SVTYPE={variant['variant_subtype']}"
+
 
             #write format field and gt
             format_list = []

--- a/tests/builds/test_build_variant.py
+++ b/tests/builds/test_build_variant.py
@@ -4,6 +4,7 @@
 from mutacc.builds.build_variant import get_variants, Variant
 
 VARIANT_FIELDS = ["variant_type",
+                  "variant_subtype",
                   "alt",
                   "ref",
                   "chrom",


### PR DESCRIPTION
Get variant category, SV, or SNV for variants. This should be added to the variant documents in the database.