### PR TITLE
Dynamic vcf parse

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+# static files
+recursive-include mutacc/resources *

--- a/mutacc/builds/build_case.py
+++ b/mutacc/builds/build_case.py
@@ -16,7 +16,7 @@ class Case(dict):
     """
         Class with methods for handling case objects
     """
-    def __init__(self, input_case, read_dir, padding=None, picard_exe=None):
+    def __init__(self, input_case, read_dir, padding=None, picard_exe=None, vcf_parse=None):
 
         """
             Object is instantiated with a case, a dictionary giving all relevant information about
@@ -36,7 +36,8 @@ class Case(dict):
         # Build variants
         rank_model_version = self.input_case['case'].get('rank_model_version')
         self['variants'] = self._build_variants(padding=padding,
-                                                rank_model_version=rank_model_version)
+                                                rank_model_version=rank_model_version,
+                                                vcf_parse=vcf_parse)
 
         # Build samples
         self['samples'] = self._build_samples(read_dir=read_dir,
@@ -45,7 +46,7 @@ class Case(dict):
         # Build case
         self['case'] = self.input_case['case']
 
-    def _build_variants(self, padding=None, rank_model_version=None):
+    def _build_variants(self, padding=None, rank_model_version=None, vcf_parse=None):
         """
             Method that parses the vcf in the case dictionary.
 
@@ -62,7 +63,8 @@ class Case(dict):
 
         for variant_object in get_variants(self.input_case["variants"],
                                            padding=padding,
-                                           rank_model_version=rank_model_version):
+                                           rank_model_version=rank_model_version,
+                                           vcf_parse=vcf_parse):
 
             # Append the variant object to the list
             variant_objects.append(variant_object)

--- a/mutacc/builds/build_case.py
+++ b/mutacc/builds/build_case.py
@@ -23,9 +23,13 @@ class Case(dict):
             the case.
 
             Args:
-
-                case(dict): dictionary containing information about the variant, with three fields;
-                            case, samples, and variants.
+                input_case(dict): dictionary containing information about the variant, with three fields;
+                                  case, samples, and variants.
+                read_dir(str): Directory fastq-files are placed
+                padding(int): given in bp, extends the region for where to look for reads in the
+                               alignment file.
+                picard_exe(str): path to picard executable
+                vcf_parse(str): path to yaml file with vcf parsing information
         """
 
         super(Case, self).__init__()
@@ -53,7 +57,10 @@ class Case(dict):
             Args:
 
                 padding(int): given in bp, extends the region for where to look for reads in the
-                alignment file.
+                              alignment file.
+                rank_model_version(str): The rank_model varsion that has been used
+                vcf_parse(str): path to yaml file with vcf parsing information
+
         """
 
         # Get padding

--- a/mutacc/cli/extract.py
+++ b/mutacc/cli/extract.py
@@ -11,7 +11,7 @@ from mutacc.parse.yaml_parse import yaml_parse
 from mutacc.builds.build_case import Case
 
 from mutacc.resources import DEMO_CASE
-
+from mutacc.resources import path_vcf_info_def
 
 LOG = logging.getLogger(__name__)
 
@@ -22,9 +22,11 @@ LOG = logging.getLogger(__name__)
                     "to include or example .yaml file in data/data.yaml")
              )
 @click.option('--padding', type=int, default=1000)
+@click.option('--vcf-parse', type=click.Path(exists=True), default=path_vcf_info_def,
+              help="yaml file with vcf parsing information")
 @click.option('--picard-executable', type=click.Path(exists=True))
 @click.pass_context
-def extract_command(context, case, padding, picard_executable):
+def extract_command(context, case, padding, vcf_parse, picard_executable):
 
     """
         extract reads from case
@@ -43,7 +45,8 @@ def extract_command(context, case, padding, picard_executable):
     case_obj = Case(input_case=input_case,
                     read_dir=read_dir,
                     padding=padding,
-                    picard_exe=picard_executable)
+                    picard_exe=picard_executable,
+                    vcf_parse=vcf_parse)
 
     import_dir = context.obj.get('import_dir')
 

--- a/mutacc/resources/__init__.py
+++ b/mutacc/resources/__init__.py
@@ -8,10 +8,14 @@ mother_bam_filename = 'resources/mother.bam'
 child_bam_filename = 'resources/child.bam'
 vcf_filename = 'resources/variant1.vcf.gz'
 
+vcf_info_def = 'resources/vcf-info-def.yaml'
+
 path_to_case_file = pkg_resources.resource_filename('mutacc', case_filename)
 path_to_background_fastq1_file = pkg_resources.resource_filename('mutacc', father_fastq1_filename)
 path_to_background_fastq2_file = pkg_resources.resource_filename('mutacc', father_fastq2_filename)
 path_to_background_bam_file = pkg_resources.resource_filename('mutacc', father_bam_filename)
+
+path_vcf_info_def = pkg_resources.resource_filename('mutacc', vcf_info_def)
 
 DEMO_CASE = {
     'case': {

--- a/mutacc/resources/vcf-info-def.yaml
+++ b/mutacc/resources/vcf-info-def.yaml
@@ -5,7 +5,7 @@
     type: list
     separator: ','
     format_separator: '|'
-    format: 'Allele|Annotation|Annotation_Impact|Gene_Name|Gene_ID|Feature_Type|Feature_ID|Transcript_BioType|Rank|HGVS.c|HGVS.p|cDNA.pos/cDNA.length|CDS.pos/CDS.length|AA.pos/AA.length|Distance|ERRORS/WARNINGS/INFO'
+    format: 'hgnc_symbol|region_annotation|functional_annotation|sift_prediction|polyphen_prediction'
     target: all
     out_type: list
 

--- a/mutacc/resources/vcf-info-def.yaml
+++ b/mutacc/resources/vcf-info-def.yaml
@@ -2,18 +2,14 @@
 
   - id: ANN
     multivalue: true
-    type: list
     separator: ','
     format_separator: '|'
     format: 'hgnc_symbol|region_annotation|functional_annotation|sift_prediction|polyphen_prediction'
     target: all
     out_type: list
+    out_name: genes
 
   - id: RankScore
-    type: str
-    multivalue: false
-    format_separator: ':'
-    format: 'case_id: rank_score'
-    target:
-      - 'rank_score'
+    multivalue: False
     out_type: int
+    out_name: RankScore

--- a/mutacc/resources/vcf-info-def.yaml
+++ b/mutacc/resources/vcf-info-def.yaml
@@ -1,0 +1,19 @@
+### IDs in INFO column that should be exracted.
+
+  - id: ANN
+    multivalue: true
+    type: list
+    separator: ','
+    format_separator: '|'
+    format: 'Allele|Annotation|Annotation_Impact|Gene_Name|Gene_ID|Feature_Type|Feature_ID|Transcript_BioType|Rank|HGVS.c|HGVS.p|cDNA.pos/cDNA.length|CDS.pos/CDS.length|AA.pos/AA.length|Distance|ERRORS/WARNINGS/INFO'
+    target: all
+    out_type: list
+
+  - id: RankScore
+    type: str
+    multivalue: false
+    format_separator: ':'
+    format: 'case_id: rank_score'
+    target:
+      - 'rank_score'
+    out_type: int

--- a/tests/builds/test_build_case.py
+++ b/tests/builds/test_build_case.py
@@ -5,8 +5,8 @@
 from pathlib import Path
 
 from mutacc.builds.build_case import Case
-
 from mutacc.parse.yaml_parse import yaml_parse
+from mutacc.resources import path_vcf_info_def
 
 CASE = yaml_parse("tests/fixtures/case.yaml")
 CASE_FASTQ = yaml_parse("tests/fixtures/case_fastq.yaml")
@@ -20,7 +20,8 @@ def test_case(tmpdir):
     tmp_dir = Path(tmpdir.mkdir("build_case_test"))
     case = Case(input_case=CASE,
                 read_dir=tmp_dir,
-                padding=100)
+                padding=100,
+                vcf_parse=path_vcf_info_def)
 
 
     for sample in case['samples']:
@@ -31,7 +32,8 @@ def test_case(tmpdir):
 
     case = Case(input_case=CASE_FASTQ,
                 read_dir=tmp_dir,
-                padding=100)
+                padding=100,
+                vcf_parse=path_vcf_info_def)
 
     for sample in case['samples']:
 

--- a/tests/builds/test_build_variant.py
+++ b/tests/builds/test_build_variant.py
@@ -1,7 +1,10 @@
 """
     Tests for build_variant.py
 """
-from mutacc.builds.build_variant import get_variants, Variant
+
+import pytest
+
+from mutacc.builds.build_variant import get_variants, Variant, INFOParser
 from mutacc.resources import path_vcf_info_def
 
 VARIANT_FIELDS = ["variant_type",
@@ -44,6 +47,7 @@ def test_variant_with_parser():
 
         assert set(variant.keys()) == set(VARIANT_FIELDS)
 
+
 def test_variant_without_parser():
     """
         Test variant without info parser
@@ -51,3 +55,93 @@ def test_variant_without_parser():
     for variant in get_variants("tests/fixtures/vcf_test.vcf", padding=300):
 
         assert set(variant.keys()) == set(VARIANT_FIELDS) - {"genes", "RankScore"}
+
+
+def test_INFOParser():
+    """
+        test instatiate INFOparser object
+    """
+    parser_file = path_vcf_info_def
+    parser = INFOParser(parser_info=path_vcf_info_def)
+    assert isinstance(parser.parsers, list)
+
+
+def test_INFOParser_check():
+    """
+        test _check method giving badly formated parsing information
+    """
+    parser_info = [{'id': 'test_id', 'multivalue': True},]
+    with pytest.raises(ValueError) as error:
+        parser = INFOParser(parser_info=parser_info)
+
+    parser_info = [{'id': 'test_id',
+                    'multivalue': True,
+                    'separator': ',',
+                    'format': '1|2',
+                    'format_separator': '|',
+                    'target': 'target'}]
+    with pytest.raises(ValueError) as error:
+        parser = INFOParser(parser_info=parser_info)
+
+    parser_info = ['element']
+    with pytest.raises(ValueError) as error:
+        parser = INFOParser(parser_info=parser_info)
+
+
+def test_INFOParser_parse():
+    """
+        Test parsing mocked variant entries given different parser info
+    """
+    # test multivalue, array of arrays, eg separated with ',' and then  '|'
+    class MockVariant():
+        def __init__(self, info_dict):
+            self.INFO = info_dict
+
+    info_dict = {'ID1': 'value11|value12,value21|value22'}
+    mock_variant = MockVariant(info_dict=info_dict)
+    parser_info = [{'id':'ID1',
+                    'multivalue': True,
+                    'separator': ',',
+                    'format': 'value1|value2',
+                    'format_separator': '|',
+                    'target': ['value1', 'value2'],
+                    'out_name': 'parsed_value'}]
+
+    parser = INFOParser(parser_info=parser_info)
+    parsed_variant = parser.parse(mock_variant)
+
+    assert parsed_variant['parsed_value'][0]['value1'] == 'value11'
+    assert parsed_variant['parsed_value'][0]['value2'] == 'value12'
+    assert parsed_variant['parsed_value'][1]['value1'] == 'value21'
+    assert parsed_variant['parsed_value'][1]['value2'] == 'value22'
+
+    # Test parsing an ID separated with ':' where we only want one element
+    info_dict = {'RankScore': 'case_1: 10'}
+    mock_variant = MockVariant(info_dict=info_dict)
+    parser_info = [{'id': 'RankScore',
+                    'multivalue': False,
+                    'format': 'case_id: rank_score',
+                    'format_separator': ':',
+                    'target': ['rank_score'],
+                    'out_name': 'rank_score',
+                    'out_type': 'int'}]
+
+    parser = INFOParser(parser_info=parser_info)
+    parsed_variant = parser.parse(mock_variant)
+
+    assert isinstance(parsed_variant['rank_score'], int)
+    assert parsed_variant['rank_score'] == 10
+
+    # Test parsing simple string
+    info_dict = {'TYPE': 'SNV'}
+    mock_variant = MockVariant(info_dict=info_dict)
+    parser_info = [{'id': 'TYPE',
+                    'multivalue': False,
+                    'out_name': 'var_type',
+                    'out_type': 'str'}]
+
+    parser = INFOParser(parser_info=parser_info)
+    parsed_variant = parser.parse(mock_variant)
+
+    assert isinstance(parsed_variant['var_type'], str)
+    assert parsed_variant['var_type'] == 'SNV'

--- a/tests/builds/test_build_variant.py
+++ b/tests/builds/test_build_variant.py
@@ -2,6 +2,7 @@
     Tests for build_variant.py
 """
 from mutacc.builds.build_variant import get_variants, Variant
+from mutacc.resources import path_vcf_info_def
 
 VARIANT_FIELDS = ["variant_type",
                   "alt",
@@ -14,7 +15,8 @@ VARIANT_FIELDS = ["variant_type",
                   "display_name",
                   "samples",
                   "padding",
-                  "genes"]
+                  "genes",
+                  "RankScore"]
 
 def test_get_variants():
     """
@@ -22,18 +24,29 @@ def test_get_variants():
     """
 
     count = 0
-    for variant in get_variants("tests/fixtures/vcf_test.vcf", padding=100):
+    for variant in get_variants("tests/fixtures/vcf_test.vcf", padding=100,
+                                vcf_parse=path_vcf_info_def):
         count += 1
         assert isinstance(variant, Variant)
 
     assert count == 7
 
 
-def test_variant():
+def test_variant_with_parser():
     """
-        Test Variant
+        Test Variant with info parser
     """
 
-    for variant in get_variants("tests/fixtures/vcf_test.vcf", padding=1000):
+    # Try with parser
+    for variant in get_variants("tests/fixtures/vcf_test.vcf", padding=1000,
+                                vcf_parse=path_vcf_info_def):
 
         assert set(variant.keys()) == set(VARIANT_FIELDS)
+
+def test_variant_without_parser():
+    """
+        Test variant without info parser
+    """
+    for variant in get_variants("tests/fixtures/vcf_test.vcf", padding=300):
+
+        assert set(variant.keys()) == set(VARIANT_FIELDS) - {"genes", "RankScore"}

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -14,6 +14,7 @@ from mutacc.mutaccDB.db_adapter import MutaccAdapter
 from mutacc.parse.yaml_parse import yaml_parse
 from mutacc.builds.build_case import Case
 from mutacc.mutaccDB.insert import insert_entire_case
+from mutacc.resources import path_vcf_info_def
 from .random_case import random_trio
 
 DATASET_DIR = "tests/fixtures/dataset/"
@@ -128,7 +129,8 @@ def mock_real_adapter(tmpdir):
     case["case"]["case_id"] = "1111"
     case = Case(input_case=case,
                 read_dir=mutacc_dir,
-                padding=200)
+                padding=200,
+                vcf_parse=path_vcf_info_def)
 
     insert_entire_case(adapter, case)
 

--- a/tests/fixtures/vcf_test.vcf
+++ b/tests/fixtures/vcf_test.vcf
@@ -1,17 +1,18 @@
 ##fileformat=VCFv4.2'
-##INFO=<ID=END,Number=1,Type=Integer,Description="Stop position of the interval">'
-##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">'
-##INFO=<ID=TYPE,Number=A,Type=String,Description="The type of allele, either snp, mnp, ins, del, or complex.">'
-##INFO=<ID=RankScore,Number=.,Type=String,Description="The rank score for this variant in this family. family_id:rank_score.">'
-##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">'
-##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Approximate read depth (reads with MQ=255 or with bad mates are filtered)">'
-##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality">'
+##INFO=<ID=END,Number=1,Type=Integer,Description="Stop position of the interval">
+##INFO=<ID=SVTYPE,Number=1,Type=String,Description="Type of structural variant">
+##INFO=<ID=ANN,Number=.,Type=String,Description="">
+##INFO=<ID=TYPE,Number=A,Type=String,Description="The type of allele, either snp, mnp, ins, del, or complex.">
+##INFO=<ID=RankScore,Number=.,Type=String,Description="The rank score for this variant in this family. family_id:rank_score.">
+##FORMAT=<ID=GT,Number=1,Type=String,Description="Genotype">
+##FORMAT=<ID=DP,Number=1,Type=Integer,Description="Approximate read depth (reads with MQ=255 or with bad mates are filtered)">
+##FORMAT=<ID=GQ,Number=1,Type=Integer,Description="Genotype Quality">
 ##FORMAT=<ID=AD,Number=R,Type=Integer,Description="Allelic depths for the ref and alt alleles in the order listed">
 #CHROM	POS	ID	REF	ALT	QUAL	FILTER	INFO	FORMAT	sample1	sample2	sample3
-1	1285001	.	G	<DEL>	.	PASS RankScore=20;SVTYPE=DEL	GT 0/1	0/1 ./.
-1	1584546	.	A	AG]19:2301862]	596	PASS	SVTYPE=BND	GT	0/1	0/1 0/1
-1	1584649	.	N	N[hs37d5:12066566[	.	PASS	SVTYPE=BND	GT	./.	./.	1/1
-1	1584805	.	N	N[hs37d5:33110541[	.	PASS	SVTYPE=BND	GT	1/1	1/1	1/1
-1	1588656	.	N	N[1:1653590[	.	PASS	SVTYPE=BND	GT	0/1	0/1	1/1
-1	1595196	.	N	N[1:1660624[	.	PASS	SVTYPE=BND	GT	0/1	./.	0/1
-4	10000500	.	G	<DEL>	.	PASS	END=10000500;SVLEN=-500;SVTYPE=DEL	GT	./.	0/1	./.
+1	1285001	.	G	<DEL>	.	PASS	RankScore=20;SVTYPE=DEL;ANN=1|1|1|1|1|1	GT	0/1	0/1	./.
+1	1584546	.	A	AG]19:2301862]	596	PASS	RankScore=20;SVTYPE=BND;ANN=1|1|1|1|1|1	GT	0/1	0/1	0/1
+1	1584649	.	N	N[hs37d5:12066566[	.	PASS	RankScore=20;SVTYPE=BND;ANN=1|1|1|1|1|1	GT	./.	./.	1/1
+1	1584805	.	N	N[hs37d5:33110541[	.	PASS	RankScore=20;SVTYPE=BND;ANN=1|1|1|1|1|1	GT	1/1	1/1	1/1
+1	1588656	.	N	N[1:1653590[	.	PASS	RankScore=20;TYPE=SNV;ANN=1|1|1|1|1|1	GT	0/1	0/1	1/1
+1	1595196	.	N	N[1:1660624[	.	PASS	RankScore=20;SVTYPE=BND;ANN=1|1|1|1|1|1	GT	0/1	./.	0/1
+4	10000500	.	G	<DEL>	.	PASS	RankScore=20;END=10000500;SVLEN=-500;SVTYPE=DEL;ANN=1|1|1|1|1|1	GT	./.	0/1	./.


### PR DESCRIPTION
Problem:
the information given in the INFO column in a vcf might be different from file to file. Currently, mutacc assumes what IDs might be in the INFO column, and parses the values based on a assumed format. This is an issue, if it is decided that the information from an additional ID field is to be included in the database, this must be changed in the code. Some formats might require some instructions on how they should be parsed, .e.g. the value might be a array, where each element is separated by a '|' symbol. There should be a way for the user to specify dynamically in a file what information from the INFO column that should be included in the database, and instructions on how these values should be parsed.

Solution:
This PR makes it possible what IDs in the INFO column of a vcf that should be included in the database. The user now have the option to specify what IDs, and how, these fields are parsed from the vcf, by specifying this information in a yaml file. In this way, information from the vcf can be included dynamically, without assuming specific vcf formats in the code.

**How to test**:
1. install on stage: `bash servers/resources/hasta.scilifelab.se/update-mutacc-stage.sh dynamic-vcf-parse`
1. activate stage: `us`
1. run following command: `cg upload process-solved --case-id <case_id>`

**Expected outcome**:
The uploaded variants should contain the same information as before. 

**Review:**
- [x] code approved by @moonso 
- [x] tests executed by @adrosenbaum 
- [x] "Merge and deploy" approved by @ingkebil 
Thanks for filling in who performed the code review and the test!

This is minor **version bump** because a feature is added in a backwards compatible manner.
