### PR TITLE
Get affected sibling

### DIFF
--- a/mutacc/utils/pedigree.py
+++ b/mutacc/utils/pedigree.py
@@ -39,6 +39,17 @@ class Family(ped_parser.Family):
 
     def get_child(self, sex=None, proband=False):
 
+        """
+            Gets child in the family
+
+            Args:
+                sex(str): Specify what sex child have
+                proband(bool): Specify if individual should be proband
+
+            Returns:
+                child(mutacc.utils.pedigree.Individual)
+        """
+
         if sex:
             if sex == "male":
                 sex = 1
@@ -46,62 +57,59 @@ class Family(ped_parser.Family):
                 sex = 2
             else:
                 sex = 0
-
         child = None
         for individual_id in self.individuals:
-
             individual = self.individuals[individual_id]
-
             if individual.has_both_parents:
-
                 if sex:
                     if individual.sex == sex:
                         child = individual
                 else:
                     child = individual
-
+                if child is not None and child.affected:
+                    break
         if not child:
             if proband and len(self.individuals.keys()) == 1:
                 for individual_id in self.individuals:
                     child = self.individuals[individual_id]
-
         return child
 
     def get_father(self):
 
+        """
+            Gets father in the family
+            Returns:
+                father(mutacc.utils.pedigree.Individual)
+        """
+
         child = self.get_child()
         if not child:
-
             return None
-
         father_id = child.father
-
         father = None
         for individual_id in self.individuals:
             individual = self.individuals[individual_id]
-
             if individual.individual_id == father_id:
-
                 father = individual
                 break
-
         return father
 
     def get_mother(self):
 
-        child = self.get_child()
+        """
+            Gets mother in the family
+            Returns:
+                mother(mutacc.utils.pedigree.Individual)
+        """
 
+        child = self.get_child()
         if not child:
             return None
-
         mother_id = child.mother
-
         mother = None
         for individual_id in self.individuals:
             individual = self.individuals[individual_id]
-
             if individual.individual_id == mother_id:
-
                 mother = individual
                 break
 
@@ -109,6 +117,13 @@ class Family(ped_parser.Family):
 
     def get_affected(self, sex=None):
 
+        """
+            Gets affected member of family
+
+            Returns:
+                affected(mutacc.utils.pedigree.Individual)
+        """
+
         if sex:
             if sex == "male":
                 sex = 1
@@ -116,31 +131,35 @@ class Family(ped_parser.Family):
                 sex = 2
             else:
                 sex = 0
-
         affected = None
         for individual_id in self.individuals:
             individual = self.individuals[individual_id]
-
             if individual.affected:
                 if sex:
                     if individual.sex == sex:
                         affected = individual
                 else:
-
                     affected = individual
-
         return affected
 
     def get_individual(self, member, sex=None, proband=False):
+        """
+            Gets specified family member
 
+            Args:
+                member(str): which family member [father|mother|child|affected]
+                sex(str): sex of family member (not applicable for mother or father)
+                proband(bool): Specify if individual should be proband (only applicable for child)
+
+            Returns:
+                (mutacc.utils.pedigree.Individual)
+        """
         members = {'father',
                    'mother',
                    'child',
                    'affected'}
-
         if member not in members:
             raise ValueError('member must be father, mother, child, or affected')
-
         if member == 'father':
             return self.get_father()
         elif member == 'mother':
@@ -183,7 +202,6 @@ def make_family_from_case(case):
             phenotype = '2'
         else:
             phenotype = '0'
-
 
         individual = Individual(
             ind=sample['sample_id'],


### PR DESCRIPTION
In case where a family contains two siblings, only the affected one is found
by default.

This branch also includes added docstrings, and refactored tests for the
pedigree module.

**How to test**:
Write unit tests

**Expected outcome**:
Unittests should pass the travis build

**Review:**
- [x] code approved by
- [x] tests executed by
Thanks for filling in who performed the code review and the test!

This is a patch **version bump** this is a bug fix
