### PR TITLE
parent name should always be string

### DIFF
--- a/mutacc/utils/pedigree.py
+++ b/mutacc/utils/pedigree.py
@@ -206,8 +206,8 @@ def make_family_from_case(case):
         individual = Individual(
             ind=sample['sample_id'],
             family=family_id,
-            mother=sample['mother'],
-            father=sample['father'],
+            mother=str(sample['mother']),
+            father=str(sample['father']),
             sex=sex,
             phenotype=phenotype,
             variant_bam_file=sample.get('variant_bam_file'),


### PR DESCRIPTION
Parent names must always be a string, otherwise the pedigree module returns an error. 

**How to test**
Unit tests in travis

**Review:**
- [x] code approved by @adrosenbaum 
- [x] tests executed by @adrosenbaum 
- [x] "Merge and deploy" approved by @adrosenbaum 
Thanks for filling in who performed the code review and the test!

This is patch version bump because it fixes bug
