### PR TITLE
feat(vcf_filter): adds filter to vcf header

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -8,3 +8,6 @@ __pycache__/
 .coverage
 .DS_Store
 .cache/
+
+# IDE
+.idea/

--- a/mutacc/utils/vcf_handler.py
+++ b/mutacc/utils/vcf_handler.py
@@ -295,6 +295,7 @@ def vcf_writer(found_variants, vcf_path, sample_name, adapter, vcf_parser=None):
             write_info_header(vcf_parser, vcf_handle)
         for header_line in VCF_HEADER:
             vcf_handle.write(header_line + NEW_LINE)
+        write_filter_headers(found_variants, vcf_handle)
         write_contigs(found_variants, vcf_handle)
         vcf_handle.write(
             f"#CHROM\tPOS\tID\tREF\tALT\tQUAL\tFILTER\tINFO\tFORMAT\t{sample_name}\n"
@@ -376,5 +377,24 @@ def write_contigs(variants, vcf_handle):
     for variant in variants:
         if variant["chrom"] in found_contigs:
             continue
-        found_contigs.update(variant["chrom"])
+        found_contigs.add(variant["chrom"])
         vcf_handle.write(template.format(variant["chrom"]) + NEW_LINE)
+
+
+def write_filter_headers(variants, vcf_handle):
+    """
+        Writes filter headers
+
+        Args:
+            variants(list(dict)): list of variants
+            vcf_handle (file handle): file handle to vcf_file
+    """
+    template = '##FILTER=<ID={},Description="{}">\n'
+    found_filters = {"PASS", DOT}
+    for variant in variants:
+        print(variant)
+        variant_filter = variant["vcf_entry"].strip(NEW_LINE).split(TAB)[6]
+        if variant_filter in found_filters:
+            continue
+        found_filters.add(variant_filter)
+        vcf_handle.write(template.format(variant_filter, variant_filter))

--- a/mutacc/utils/vcf_handler.py
+++ b/mutacc/utils/vcf_handler.py
@@ -392,7 +392,6 @@ def write_filter_headers(variants, vcf_handle):
     template = '##FILTER=<ID={},Description="{}">\n'
     found_filters = {"PASS", DOT}
     for variant in variants:
-        print(variant)
         variant_filter = variant["vcf_entry"].strip(NEW_LINE).split(TAB)[6]
         if variant_filter in found_filters:
             continue

--- a/tests/conftest.py
+++ b/tests/conftest.py
@@ -178,7 +178,7 @@ VARIANT1 = {
     "case": "1111",
 }
 VARIANT2 = {
-    "vcf_entry": "6\t75071643\t.\tT\t<DUP>\t100\tPASS\tSOMATIC;SVTYPE=INV\tGT\t./.",
+    "vcf_entry": "6\t75071643\t.\tT\t<DUP>\t100\tPloidy\tSOMATIC;SVTYPE=INV\tGT\t./.",
     "end": 123,
     "chrom": "X",
     "genotype": {"GT": "1/1", "DP": 30},

--- a/tests/utils/test_vcf_handler.py
+++ b/tests/utils/test_vcf_handler.py
@@ -10,6 +10,7 @@ from mutacc.utils.vcf_handler import (
     vcf_writer,
     write_info_header,
     write_contigs,
+    write_filter_headers
 )
 
 
@@ -240,3 +241,19 @@ def test_write_contigs(tmpdir, variants):
     with open(out_vcf, "r") as vcf_handle:
         for line in vcf_handle:
             assert line.startswith("##contig=<ID=")
+
+
+def test_write_filter_headers(tmpdir, variants):
+
+    # GIVEN a file path and a list of variants
+    out_path = Path(tmpdir.mkdir("test_vcf_writer"))
+    out_vcf = out_path.joinpath("test_write_filters.vcf")
+
+    # WHEN writing the filters in the header
+    with open(out_vcf, "w") as vcf_handle:
+        write_filter_headers(variants, vcf_handle)
+
+    # THEN all lines should start with '##FILTER=<ID='
+    with open(out_vcf, "r") as vcf_handle:
+        line = vcf_handle.readline()
+        assert line == '##FILTER=<ID=Ploidy,Description="Ploidy">\n'


### PR DESCRIPTION
This PR adds the filter field in the vcf header for variants that don't have PASS in their filter column. Additionally it fixes an issue where some contigs where added multiple times to the vcf header
 
**How to test**:
1. `conda activate S_mutacc`
2. Install on hasta stage: 
    `bash /home/proj/stage/servers/resources/hasta.scilifelab.se/update-mutacc-stage.sh feature/add_filter`
3. Run `mutacc -c /home/proj/stage/servers/config/hasta.scilifelab.se/mutacc.yaml db export --all-variants`
4. Open the produced vcf

**Expected outcome**:
- [x] Filters other than PASS should be added to the vcf header
- [x] Only on entry of each contig in the header


**Review:**
- [ ] code approved by
- [x] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This is a patch **version bump**