### PR TITLE
Run Docker commands as non-root user and created docker-compose file

### DIFF
--- a/.github/workflows/docker_build_n_publish.yml
+++ b/.github/workflows/docker_build_n_publish.yml
@@ -1,0 +1,22 @@
+name: Publish to Docker Hub
+
+on:
+ release:
+  types:
+   - created
+
+jobs:
+  docker-image-CI:
+   name: Docker Image CI
+   runs-on: ubuntu-latest
+   steps:
+    - name: Check out git repository
+      uses: actions/checkout@v2
+
+    - name: Publish to Registry
+      uses: elgohr/Publish-Docker-Github-Action@master
+      with:
+        name: clinicalgenomics/patientmatcher
+        username: ${{ secrets.DOCKER_USERNAME }}
+        password: ${{ secrets.DOCKER_PASSWORD }}
+        tags: "latest,${{ github.event.release.tag_name }}"

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,9 +3,9 @@ All notable changes to this project will be documented in this file.
 
 ## []
 ### Added
-- A docker-compose file that loads demo data on a MongoDB instance and exports results to host current directory
+- A docker-compose file that loads demo data on a MongoDB instance and exports results to the current directory of the user
 ### Changed
-- Dockerfile now based on a miniconda3 image and commands are runned from non-root user
+- Dockerfile now based on a miniconda3 image with commands runned as a non-root user
 
 ## [1.3.0]
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## []
+### Added
+- A docker-compose file that loads demo data on a MongoDB instance and exports results to host current directory
+### Changed
+- Dockerfile now based on a miniconda3 image and commands are runned from non-root user
+
 ## [1.3.0]
 
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## []
 ### Added
 - A docker-compose file that loads demo data on a MongoDB instance and exports results to the current directory of the user
+- A GitHub actions building a repo image and pushing it to Docker Hub whenever a new release is published
 ### Changed
 - Dockerfile now based on a miniconda3 image with commands runned as a non-root user
 

--- a/README.md
+++ b/README.md
@@ -12,6 +12,26 @@ variant from a real NGS data, *mutacc* stores the relevant reads from each case 
 a database. This database can then be queried to create synthetic datasets that can
 be used as positive controls bioinformatics pipelines.
 
+
+## Running the app using Docker (No installation of any software or database required)
+An example containing a demo setup for the app is included in the docker-compose file. Note that this file is not intended for use in production and is only provided to illustrate how an image containing the application could be connected to a MongoDB instance and perform commands provided when running it as a container. A Docker image file for Mutacc can be pulled from [Docker Hub](https://hub.docker.com/repository/docker/clinicalgenomics/mutacc), or can be built from the Dockerfile provided in the GitHub repository folder. Start the docker-compose demo using this command:
+
+```console
+docker-compose up -d
+```
+
+What the docker-compose command does:
+
+- Starts the database
+- extracts the reads from a demo case (demo case resouces are located under /mutacc/resources)
+- Saves them to database
+- Exports them from the database to a local file
+
+When the above command is executed, it creates the following 4 directories: `reads`, `imports`, `queries` and `variants` in the working directory. The directory names `variants` contains the vcf with the variants of interest for this demo case.
+
+After running the test, don't forget to run docker-compose to remove containers, networks, volumes and images created by docker-compose.
+
+
 ## Installation
 ### Conda
 For installation of mutacc and the external prerequisites, this is made easy by

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,17 +13,30 @@ services:
     expose:
       - '27017'
 
-  # Service that extracts the reads from the case and saves them to database
-  mutacc-demodata:
+  # Does nothing for now, but can be invoked to run commands
+  mutacc-cli:
     build: .
-    image: mutacc-demodata
+    container_name: mutacc-cli
+    networks:
+      - mutacc-net
+    depends_on:
+      - mongodb
+      - mutacc-demodata
+
+  # Service that extracts the reads from the case and saves them to database and exports results
+  mutacc-demodata:
+    image: mutacc-cli
+    container_name: mutacc-demodata
     networks:
       - mutacc-net
     depends_on:
       - mongodb
     command: bash -c "
       mutacc --root-dir . extract --padding 600 -c mutacc/resources/case.yaml &&
-      mutacc --root-dir . db -h mongodb -p 27017 import /home/worker/app/imports/demo_trio_import.mutacc"
+      mutacc --root-dir . db -h mongodb -p 27017 import /home/worker/app/imports/demo_trio_import.mutacc &&
+      mutacc --root-dir . db -h mongodb -p 27017 export -m affected"
+    volumes:
+        - ./:/home/worker/app
 
 networks:
   mutacc-net:

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -13,19 +13,9 @@ services:
     expose:
       - '27017'
 
-  # Does nothing for now, but can be invoked to run commands
-  mutacc-cli:
-    build: .
-    container_name: mutacc-cli
-    networks:
-      - mutacc-net
-    depends_on:
-      - mongodb
-      - mutacc-demodata
-
   # Service that extracts the reads from the case and saves them to database and exports results
   mutacc-demodata:
-    image: mutacc-cli
+    build: .
     container_name: mutacc-demodata
     networks:
       - mutacc-net

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -1,0 +1,30 @@
+version: '3'
+# usage:
+# (sudo) docker-compose up
+# (sudo) docker-compose down
+services:
+  mongodb:
+    image: mongo:4.4.9
+    container_name: mongodb
+    networks:
+      - mutacc-net
+    ports:
+      - '27017:27017'
+    expose:
+      - '27017'
+
+  # Service that extracts the reads from the case and saves them to database
+  mutacc-demodata:
+    build: .
+    image: mutacc-demodata
+    networks:
+      - mutacc-net
+    depends_on:
+      - mongodb
+    command: bash -c "
+      mutacc --root-dir . extract --padding 600 -c mutacc/resources/case.yaml &&
+      mutacc --root-dir . db -h mongodb -p 27017 import /home/worker/app/imports/demo_trio_import.mutacc"
+
+networks:
+  mutacc-net:
+    driver: bridge


### PR DESCRIPTION
This PR does the following:
- Adds docker-compose file that loads demo data on a MongoDB instance and exports results to host current directory (fix #72 )
- Modified the Dockerfile to be based on a miniconda3 image. Its commands are now runned as a non-root user

**How to test**:
- [x] Start by checking if the Dockerimage builds: `docker build -t mutacc . `
You can try to run commands interactively directly on the container by running:
- [x] `docker run --rm -it --entrypoint /bin/sh mutacc`
- [x] From the image shell, try to run mutacc commands that don't need interaction with the database, like `mutacc --root-dir . extract --padding 600 -c mutacc/resources/case.yaml`

Then you could check if the docker-compose file works. What it does:
- Starts the database
- extracts the reads from a demo case
- Saves them to database
- Exports them from the database to a local file

- [x] To check that it works run "docker-compose up" and 4 directories with data will be created in your current directory

**Expected outcome**:
All the commands above should work

**Review:**
- [x] code approved by HS
- [x] tests executed by CR
Thanks for filling in who performed the code review and the test!

This is patch|minor|major **version bump** because ...
