### PR TITLE
Prepare version 1.5

### DIFF
--- a/.github/workflows/pypi_build_n_publish.yml
+++ b/.github/workflows/pypi_build_n_publish.yml
@@ -1,0 +1,40 @@
+name: Publish to PyPI
+
+on:
+ push:
+  tags:
+   - '*'
+
+jobs:
+ build-n-publish:
+  name: Build and publish Python distribution to PyPI
+  runs-on: ubuntu-18.04
+  steps:
+   - name: Check out git repository
+     uses: actions/checkout@v2
+
+   - name: Set up Python 3.7
+     uses: actions/setup-python@v2
+     with:
+      python-version: 3.7
+
+   - name: Install build tools
+     run: >-
+        python -m
+        pip install
+        wheel
+        twine
+        --user
+
+   - name: Build a binary wheel and a source tarball
+     run: >-
+        python
+        setup.py
+        sdist
+        bdist_wheel
+
+   - name: Publish distribution 📦 to PyPI
+     uses: pypa/gh-action-pypi-publish@master
+     with:
+       user: __token__
+       password: ${{ secrets.pypi_password }}

--- a/.github/workflows/pypi_build_n_publish.yml
+++ b/.github/workflows/pypi_build_n_publish.yml
@@ -1,9 +1,9 @@
 name: Publish to PyPI
 
 on:
- push:
-  tags:
-   - '*'
+ release:
+  types:
+   - created
 
 jobs:
  build-n-publish:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,8 +4,9 @@ All notable changes to this project will be documented in this file.
 ## [1.5]
 ### Added
 - A docker-compose file that loads demo data on a MongoDB instance and exports results to the current directory of the user
-- A GitHub actions building a repo image and pushing it to Docker Hub whenever a new release is published
+- GitHub action building a repo image and pushing it to Docker Hub when a new release is published
 - A command line option to allow mongo URI connections (already supported from config file)
+- GitHub action building a repo image and pushing it to PyPI when a new release is published
 ### Changed
 - Dockerfile now based on a miniconda3 image with commands runned as a non-root user
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-## []
+## [1.5]
 ### Added
 - A docker-compose file that loads demo data on a MongoDB instance and exports results to the current directory of the user
 - A GitHub actions building a repo image and pushing it to Docker Hub whenever a new release is published

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,7 @@ All notable changes to this project will be documented in this file.
 - A docker-compose file that loads demo data on a MongoDB instance and exports results to the current directory of the user
 - GitHub action building a repo image and pushing it to Docker Hub when a new release is published
 - A command line option to allow mongo URI connections (already supported from config file)
-- GitHub action building a repo image and pushing it to PyPI when a new release is published
+- GitHub action building the software and publishing it to PyPI when a new release is published
 ### Changed
 - Dockerfile now based on a miniconda3 image with commands runned as a non-root user
 

--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ docker-compose up -d
 What the docker-compose command does:
 
 - Starts the database
-- extracts the reads from a demo case (demo case resouces are located under /mutacc/resources)
+- extracts the reads from a demo case (demo case resources are located under /mutacc/resources)
 - Saves them to database
 - Exports them from the database to a local file
 


### PR DESCRIPTION
This PR assigns a version to the latest changes introduced to the repo. Next step would be creating a new version with bumpversion. 

Question: do we want to create a GitHub action that pushes the new version to PyPi as well? Because in the instructions it says that the repo should be installed with the command `pip install mutacc`..

**How to test**:
1. No tests needed, the only changes are descriptive.

**Review:**
- [x] code approved by HS
Thanks for filling in who performed the code review and the test!

This is patch|minor|major **version bump** because ...
