### PR TITLE
Update the dependecy to use a fixed version of mongo-adapter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ All notable changes to this project will be documented in this file.
 ### Fixed
 - Parse yaml config files using `yaml.safe_load` to avoid `missing Loader error` due to deprecation introduced by PyYAML 6.0
 - Typo in docker-compose file
-- Fix mongo-adapter dependency to use version>=3.3. Previous versions have a way too short connection timeout and approximate URI log print
+- Fix mongo-adapter dependency to use version>=0.3.3. Previous versions have a way too short connection timeout and approximate URI log print
 
 ## [1.5]
 ### Added

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## []
+### Fixed
+- Depend on mongo-adapter>=3.3. Previous versions have a way too short connection timeout and approximate log_uri print
+
 ## [1.5]
 ### Added
 - A docker-compose file that loads demo data on a MongoDB instance and exports results to the current directory of the user

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ pysam
 coloredlogs
 biopython
 cyvcf2<0.10.0
-mongo-adapter
+mongo-adapter>=3.3
 ped_parser
 PyYaml>=5.1
 pymongo

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ pysam
 coloredlogs
 biopython
 cyvcf2<0.10.0
-mongo-adapter>=3.3
+mongo_adapter>=0.3.3
 ped_parser
 PyYaml>=5.1
 pymongo


### PR DESCRIPTION
This is a patch reflecting the recent fixes in mongo-adapter: https://github.com/Clinical-Genomics/mongo_adapter/pull/3

**Review:**
- [x] code approved by DN
- [x] tests executed by CR
Thanks for filling in who performed the code review and the test!
