### PR TITLE
Multi-stage optimized -SMALLER- Dockerimage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@ All notable changes to this project will be documented in this file.
 ## []
 ### Changed
 - Build and use local Dockerfile when creating demo container in docker-compose
+- Optimize Dockerfile by adding multi-stage vuild and basing builder on pre-existing cyvcf2 image
 ### Fixed
 - Parse yaml config files using `yaml.safe_load` to avoid `missing Loader error` due to deprecation introduced by PyYAML 6.0
 - Typo in docker-compose file

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,7 @@ All notable changes to this project will be documented in this file.
 ## []
 ### Changed
 - Build and use local Dockerfile when creating demo container in docker-compose
-- Optimize Dockerfile by adding multi-stage vuild and basing builder on pre-existing cyvcf2 image
+- Minify Docker image by adding a multi-stage build and manually installing Picard and the Java Virtual Machine
 ### Fixed
 - Parse yaml config files using `yaml.safe_load` to avoid `missing Loader error` due to deprecation introduced by PyYAML 6.0
 - Typo in docker-compose file

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,9 +1,19 @@
 ###########
 # BUILDER #
 ###########
-FROM northwestwitch/python3.8-cyvcf2-venv:1.0 AS python-builder
-
+FROM python:3.7.3-slim-stretch as builder
 ENV PATH="/venv/bin:$PATH"
+
+RUN apt-get update && \
+    apt-get -y upgrade && \
+    apt-get -y install -y --no-install-recommends gcc libc-dev libz-dev
+
+# Install virtualenv
+RUN pip install virtualenv
+RUN virtualenv --seeder pip /venv
+
+ENV picard_version 2.26.5
+ADD https://github.com/broadinstitute/picard/releases/download/${picard_version}/picard.jar /libs/
 
 WORKDIR /app
 
@@ -15,28 +25,32 @@ RUN pip install --no-cache-dir -r requirements.txt
 #########
 # FINAL #
 #########
-FROM python:3.8-slim
+
+FROM python:3.7.3-slim-stretch as deployer
 
 LABEL about.home="https://github.com/Clinical-Genomics/mutacc"
 LABEL about.documentation="https://github.com/Clinical-Genomics/mutacc/blob/master/docs/demo.md"
 LABEL about.license="MIT License (MIT)"
 
-# Do not upgrade to the latest pip version to ensure more reproducible builds
-ENV PIP_DISABLE_PIP_VERSION_CHECK=1
-ENV PATH="/venv/bin:$PATH"
-RUN echo export PATH="/venv/bin:\$PATH" > /etc/profile.d/venv.sh
+RUN mkdir -p /usr/share/man/man1 && \
+ 		apt-get update && \
+    apt-get -y upgrade && \
+    apt-get -y install -y --no-install-recommends openjdk-8-jre
 
 # Create a non-root user to run commands
-RUN groupadd --gid 10001 worker && useradd -g worker --uid 10001 --shell /usr/sbin/nologin --create-home worker
+RUN groupadd --gid 10001 worker && useradd -g worker --uid 10001 --create-home worker
+
+WORKDIR /home/worker/app
+COPY . /home/worker/app
 
 # Copy virtual environment from builder
-COPY --chown=worker:worker --from=python-builder /venv /venv
+ENV PATH="/venv/bin:$PATH"
+COPY --chown=worker:worker --from=builder /venv /venv
+COPY --chown=worker:worker --from=builder /libs /home/worker/libs
 
-WORKDIR /worker/app
-COPY . /worker/app
+RUN echo export PATH="/venv/bin:\$PATH" > /etc/profile.d/venv.sh
 
 # Install the app
 RUN pip install --no-cache-dir .
 
-# Run the app as non-root user
 USER worker

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -22,7 +22,7 @@ services:
     depends_on:
       - mongodb
     command: bash -c "
-      mutacc --root-dir . extract --padding 600 -c mutacc/resources/case.yaml &&
+      mutacc --root-dir . extract --picard-executable /home/worker/libs/picard.jar --padding 600 -c mutacc/resources/case.yaml &&
       mutacc --root-dir . db -h mongodb -p 27017 import /home/worker/app/imports/demo_trio_import_mutacc.json &&
       mutacc --root-dir . db -h mongodb -p 27017 export -m affected"
     volumes:


### PR DESCRIPTION
- Create a much smaller image by introducing a multi-stage build (1.41 GB to 633 Mb). Fix #82 

**How to test**:
1. Run docker-compose up and make sure that the result oufiles are created correctly

**Review:**
- [ ] code approved by
- [x] tests executed by CR
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This is patch|minor|major **version bump** because ...
