### PR TITLE
Speed up Docker image building by basing it on a cyvcf2 image

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Build and use local Dockerfile when creating demo container in docker-compose
 - Minify Docker image by adding a multi-stage build and manually installing Picard and the Java Virtual Machine
+- Speed up Docker image compiling by basing it on another image with cyvcf2 already installed
 ### Fixed
 - Parse yaml config files using `yaml.safe_load` to avoid `missing Loader error` due to deprecation introduced by PyYAML 6.0
 - Typo in docker-compose file

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,26 +1,19 @@
 ###########
 # BUILDER #
 ###########
-FROM python:3.7.3-slim-stretch as builder
+FROM clinicalgenomics/python3.7.3-slim-stretch-cyvcf2-venv:1.0 AS builder
+
 ENV PATH="/venv/bin:$PATH"
-
-RUN apt-get update && \
-    apt-get -y upgrade && \
-    apt-get -y install -y --no-install-recommends gcc libc-dev libz-dev
-
-# Install virtualenv
-RUN pip install virtualenv
-RUN virtualenv --seeder pip /venv
-
-ENV picard_version 2.26.5
-ADD https://github.com/broadinstitute/picard/releases/download/${picard_version}/picard.jar /libs/
 
 WORKDIR /app
 
-# Install Mutacc dependencies
+# Install Scout dependencies
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
+# Download Picard
+ENV picard_version 2.26.5
+ADD https://github.com/broadinstitute/picard/releases/download/${picard_version}/picard.jar /libs/
 
 #########
 # FINAL #
@@ -46,9 +39,10 @@ COPY . /home/worker/app
 # Copy virtual environment from builder
 ENV PATH="/venv/bin:$PATH"
 COPY --chown=worker:worker --from=builder /venv /venv
-COPY --chown=worker:worker --from=builder /libs /home/worker/libs
-
 RUN echo export PATH="/venv/bin:\$PATH" > /etc/profile.d/venv.sh
+
+# Copy Picard executable in user home, /libs
+COPY --chown=worker:worker --from=builder /libs /home/worker/libs
 
 # Install the app
 RUN pip install --no-cache-dir .

--- a/Dockerfile
+++ b/Dockerfile
@@ -7,7 +7,7 @@ ENV PATH="/venv/bin:$PATH"
 
 WORKDIR /app
 
-# Install Scout dependencies
+# Install Mutacc dependencies
 COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 


### PR DESCRIPTION
Fix #78

**How to test**:
- [x] Build the image and make sure that built time is faster than the image from master branch
- [x] Run docker-compose up and make sure it produces the expected outfiles

**Review:**
- [ ] code approved by
- [x] tests executed by CR
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This is a minor, since it's not really fixing a bug, but it's optimizing the docker build performance
