### PR TITLE
Prepare new minor version 1.6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-## []
+## [1.6]
 ### Changed
 - Build and use local Dockerfile when creating demo container in docker-compose
 - Minify Docker image by adding a multi-stage build and manually installing Picard and the Java Virtual Machine

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ All notable changes to this project will be documented in this file.
 ### Changed
 - Build and use local Dockerfile when creating demo container in docker-compose
 - Minify Docker image by adding a multi-stage build and manually installing Picard and the Java Virtual Machine
-- Speed up Docker image compiling by basing it on another image with cyvcf2 already installed
+- Speed up Docker image building by basing it on another image with cyvcf2 already installed
 ### Fixed
 - Parse yaml config files using `yaml.safe_load` to avoid `missing Loader error` due to deprecation introduced by PyYAML 6.0
 - Typo in docker-compose file


### PR DESCRIPTION
## [1.6]
### Changed
- Build and use local Dockerfile when creating demo container in docker-compose
- Minify Docker image by adding a multi-stage build and manually installing Picard and the Java Virtual Machine
- Speed up Docker image compiling by basing it on another image with cyvcf2 already installed
### Fixed
- Parse yaml config files using `yaml.safe_load` to avoid `missing Loader error` due to deprecation introduced by PyYAML 6.0
- Typo in docker-compose file
- Fix mongo-adapter dependency to use version>=0.3.3. Previous versions have a way too short connection timeout and approximate URI log print

**Review:**
- [ ] code approved by
- [x] tests executed by CR
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This is patch|minor|major **version bump** because ...
