### PR TITLE
Fixed name of the token used by PyPI push action

### DIFF
--- a/.github/workflows/pypi_build_n_publish.yml
+++ b/.github/workflows/pypi_build_n_publish.yml
@@ -37,4 +37,4 @@ jobs:
      uses: pypa/gh-action-pypi-publish@master
      with:
        user: __token__
-       password: ${{ secrets.pypi_password }}
+       password: ${{ secrets.mutacc }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [1.6.1]
+### Fixed
+- Token name used by PyPI push action
+
 ## [1.6]
 ### Changed
 - Build and use local Dockerfile when creating demo container in docker-compose


### PR DESCRIPTION
The name of the token of the action did not correspond to the token name on PyPI , so the action failed

**Review:**
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This is patch|minor|major **version bump** because ...
