### PR TITLE
Fix pypi push token info once again (and create a new release)

### DIFF
--- a/.github/workflows/pypi_build_n_publish.yml
+++ b/.github/workflows/pypi_build_n_publish.yml
@@ -37,4 +37,4 @@ jobs:
      uses: pypa/gh-action-pypi-publish@master
      with:
        user: __token__
-       password: ${{ secrets.mutacc }}
+       password: ${{ secrets.PYPI_TOKEN }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,9 +1,13 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [1.6.2]
+### Fixed
+- Token name used by PyPI push action once again
+
 ## [1.6.1]
 ### Fixed
-- Token name used by PyPI push action (x2)
+- Token name used by PyPI push action
 
 ## [1.6]
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,7 @@ All notable changes to this project will be documented in this file.
 
 ## [1.6.1]
 ### Fixed
-- Token name used by PyPI push action
+- Token name used by PyPI push action (x2)
 
 ## [1.6]
 ### Changed


### PR DESCRIPTION
Modify GitHub Action PyPI push token once again

**How to test**:
1. Create a new release and make sure the PyPI push action works.

**Review:**
- [x] code approved by HS
- [ ] tests executed by GitHub actions
Thanks for filling in who performed the code review and the test!

This is patch|minor|major **version bump** because ...
