### PR TITLE
Freeze PyMongo lib to version<4.0 to keep supporting previous MongoDB versions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [1.6.3]
+### Fixed
+- Freeze PyMongo lib to version<4.0 to keep supporting previous MongoDB versions
+
 ## [1.6.2]
 ### Fixed
 - Token name used by PyPI push action once again

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ cyvcf2<0.10.0
 mongo_adapter>=0.3.3
 ped_parser
 PyYaml>=5.1
-pymongo
+pymongo<4.0


### PR DESCRIPTION
Fix #87 

**Review:**
- [ ] code approved by
- [ ] tests executed by
- [ ] "Merge and deploy" approved by
Thanks for filling in who performed the code review and the test!

This is patch because it's fixing an eventual problem
