### PR TITLE
Fix broken installation by using Python>=3.8

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,12 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [unreleased]
+### Fixed
+- Unfreeze cyvcf2 lib to be able to install the software with Python>=3.8
+### Changed
+- Installation instructions on README page to install mutacc using Python 3.8
+
 ## [1.6.3]
 ### Fixed
 - Freeze PyMongo lib to version<4.0 to keep supporting previous MongoDB versions

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ For installation of mutacc and the external prerequisites, this is made easy by
 creating conda environment
 
 ```consol
-conda create -n <env_name> python=3.6 pip numpy cython
+conda create -n <env_name> python=3.8 pip numpy cython
 ```
 
 activate environment

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ Click
 pysam
 coloredlogs
 biopython
-cyvcf2<0.10.0
+cyvcf2
 mongo_adapter>=0.3.3
 ped_parser
 PyYaml>=5.1

--- a/setup.py
+++ b/setup.py
@@ -128,7 +128,7 @@ setup(
         # Trove classifiers
         # Full list: https://pypi.python.org/pypi?%3Aaction=list_classifiers
         'License :: OSI Approved :: MIT License',
-        'Programming Language :: Python :: 3.6',
+        'Programming Language :: Python :: 3.8',
         'Environment :: Console'
     ],
     # $ setup.py publish support.


### PR DESCRIPTION
Fix #93 and fix #92

**How to test**:
1. Create a conda env with python 3.8 and follow the installation instructions 
1. Run any command 
1. run following command: `cg get coffee`

**Expected outcome**:
`mutacc` should be installed

**Review:**
- [ ] code approved by
- [x] tests executed by CR

This is patch|minor|major **version bump** because ...
