### PR TITLE
Unfreeze pymongo and add integration test with MongoDB v7

### DIFF
--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -21,7 +21,12 @@ jobs:
         with:
           activate-conda: true
           python-version: 3.11
-      - run: conda install --yes -c bioconda seqkit picard
+      - run: conda install --yes -c seqkit
+
+      - name: Download Picard
+          uses: wei/wget@v1
+          with:
+            args: -O picard.jar https://github.com/broadinstitute/picard/releases/download/2.26.6/picard.jar
 
       - name: Install repo and its dependencies
         run: |

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -21,15 +21,12 @@ jobs:
         with:
           activate-conda: true
           python-version: 3.11
+      - run: conda install --yes -c bioconda seqkit picard
 
       - name: Install repo and its dependencies
         run: |
           pip install -r requirements.txt
           pip install -e .
-      - name: Download Picard
-        uses: wei/wget@v1
-        with:
-          args: -O picard.jar https://github.com/broadinstitute/picard/releases/download/2.26.6/picard.jar
 
       - name: Test run pipeline
         run: |

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -21,12 +21,11 @@ jobs:
         with:
           activate-conda: true
           python-version: 3.11
-      - run: conda install --yes -c seqkit
 
       - name: Download Picard
-          uses: wei/wget@v1
-          with:
-            args: -O picard.jar https://github.com/broadinstitute/picard/releases/download/2.26.6/picard.jar
+        uses: wei/wget@v1
+        with:
+          args: -O picard.jar https://github.com/broadinstitute/picard/releases/download/2.26.6/picard.jar
 
       - name: Install repo and its dependencies
         run: |

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -1,0 +1,38 @@
+name: Integration tests
+on: [pull_request]
+jobs:
+  integration_test:
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        mongodb-version: ['7']
+
+    steps:
+      - name: Start MongoDB
+        uses: supercharge/mongodb-github-action@1
+        with:
+          mongodb-version: ${{ matrix.mongodb-version }}
+
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Setup Conda and install python
+        uses: s-weigand/setup-conda@v1
+        with:
+          activate-conda: true
+          python-version: 3.11
+
+      - name: Install repo and its dependencies
+        run: |
+          pip install -r requirements.txt
+          pip install -e .
+      - name: Download Picard
+        uses: wei/wget@v1
+        with:
+          args: -O picard.jar https://github.com/broadinstitute/picard/releases/download/2.26.6/picard.jar
+
+      - name: Test run pipeline
+        run: |
+          mutacc --root-dir . extract --picard-executable picard.jar --padding 600 -c mutacc/resources/case.yaml
+          mutacc --root-dir . db import imports/demo_trio_import_mutacc.json
+          mutacc --root-dir . db export --all-variants --member child --proband --sample-name child

--- a/.github/workflows/integration_test.yml
+++ b/.github/workflows/integration_test.yml
@@ -9,7 +9,7 @@ jobs:
 
     steps:
       - name: Start MongoDB
-        uses: supercharge/mongodb-github-action@1
+        uses: supercharge/mongodb-github-action@1.10.0
         with:
           mongodb-version: ${{ matrix.mongodb-version }}
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,14 @@
 All notable changes to this project will be documented in this file.
 
 ## [unreleased]
+### Added
+- Integration test with MongoDB v7 
 ### Changed
 - Moved tests and coverage from Travis to GitHub actions
 - Updated python version and versions of some GitHub actions
 - Unfreeze cyvcf2 lib to be able to install the software with Python>=3.8
 - Installation instructions on README page to install mutacc using Python 3.8
+- Unfreeze pymongo requirement and removed deprecated pymongo code to support latest version of MongoDB
 ### Fixed
 - Badge on Readme page
 - GitHub action to push the right image to Docker Hub

--- a/mutacc/mutaccDB/db_adapter.py
+++ b/mutacc/mutaccDB/db_adapter.py
@@ -68,20 +68,10 @@ class MutaccAdapter(MongoAdapter):
 
         self.cases_collection.insert_one(case)
 
-    def case_exists(self, case_id):
-        """
-            Check if collection with field 'case_id': case_id exists.
+    def case_exists(self, case_id:str) ->  bool:
+        """Check if collection with field 'case_id': case_id exists."""
 
-            Args:
-                case_id(str): name of case
-            Returns:
-                exists(bool): True if exists, else False
-        """
-
-        if self.cases_collection.find({"case_id": case_id}).count() > 0:
-            return True
-
-        return False
+        return self.cases_collection.count_documents({"case_id": case_id}) > 0
 
     def find_cases(self, query):
 

--- a/mutacc/mutaccDB/db_adapter.py
+++ b/mutacc/mutaccDB/db_adapter.py
@@ -68,7 +68,7 @@ class MutaccAdapter(MongoAdapter):
 
         self.cases_collection.insert_one(case)
 
-    def case_exists(self, case_id:str) ->  bool:
+    def case_exists(self, case_id: str) ->  bool:
         """Check if collection with field 'case_id': case_id exists."""
 
         return self.cases_collection.count_documents({"case_id": case_id}) > 0

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,4 +6,4 @@ cyvcf2
 mongo_adapter>=0.3.3
 ped_parser
 PyYaml>=5.1
-pymongo<4.0
+pymongo


### PR DESCRIPTION
Changes introduced by this PR:
- Unfreeze pymongo requirement and removed deprecated pymongo code to support latest version of MongoDB
- Added Integration test with MongoDB v7 


**How to test**:
- Make sure the new integration test action works

**Review:**
- [x] code approved by HS
- [x] tests executed by GitHub actions

Minor release
