### PR TITLE
Updated python to v3.11 in Dockerfile and MongoDB to v7 in docker-compose

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,8 @@ All notable changes to this project will be documented in this file.
 - Unfreeze cyvcf2 lib to be able to install the software with Python>=3.8
 - Installation instructions on README page to install mutacc using Python 3.8
 - Unfreeze pymongo requirement and removed deprecated pymongo code to support latest version of MongoDB
+- Updated pythin version to 3.11 in Dockerfile
+- Updated MongoDB version to 7 in docker-compose.yml file
 ### Fixed
 - Badge on Readme page
 - GitHub action to push the right image to Docker Hub

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,7 +1,7 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
-## [unreleased]
+## [1.7]
 ### Added
 - Integration test with MongoDB v7 
 ### Changed

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 ###########
 # BUILDER #
 ###########
-FROM clinicalgenomics/python3.7.3-slim-stretch-cyvcf2-venv:1.0 AS builder
+FROM clinicalgenomics/python3.11-venv:1.0 AS builder
 
 ENV PATH="/venv/bin:$PATH"
 
@@ -12,23 +12,23 @@ COPY requirements.txt .
 RUN pip install --no-cache-dir -r requirements.txt
 
 # Download Picard
-ENV picard_version 2.26.5
-ADD https://github.com/broadinstitute/picard/releases/download/${picard_version}/picard.jar /libs/
+ENV picard_version 3.10
+ADD https://github.com/broadinstitute/picard/releases/download/3.1.0/picard.jar /libs/
 
 #########
 # FINAL #
 #########
 
-FROM python:3.7.3-slim-stretch as deployer
+FROM clinicalgenomics/python3.11-venv:1.0 as deployer
 
 LABEL about.home="https://github.com/Clinical-Genomics/mutacc"
 LABEL about.documentation="https://github.com/Clinical-Genomics/mutacc/blob/master/docs/demo.md"
 LABEL about.license="MIT License (MIT)"
 
 RUN mkdir -p /usr/share/man/man1 && \
- 		apt-get update && \
+ 	apt-get update && \
     apt-get -y upgrade && \
-    apt-get -y install -y --no-install-recommends openjdk-8-jre
+    apt-get -y install -y --no-install-recommends openjdk-17-jre
 
 # Create a non-root user to run commands
 RUN groupadd --gid 10001 worker && useradd -g worker --uid 10001 --create-home worker
@@ -48,3 +48,4 @@ COPY --chown=worker:worker --from=builder /libs /home/worker/libs
 RUN pip install --no-cache-dir .
 
 USER worker
+

--- a/Dockerfile
+++ b/Dockerfile
@@ -13,7 +13,7 @@ RUN pip install --no-cache-dir -r requirements.txt
 
 # Download Picard
 ENV picard_version 3.10
-ADD https://github.com/broadinstitute/picard/releases/download/3.1.0/picard.jar /libs/
+ADD https://github.com/broadinstitute/picard/releases/download/${picard_version}/picard.jar /libs/
 
 #########
 # FINAL #

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -4,7 +4,7 @@ version: '3'
 # (sudo) docker-compose down
 services:
   mongodb:
-    image: mongo:4.4.9
+    image: mongo:7
     container_name: mongodb
     networks:
       - mutacc-net


### PR DESCRIPTION
Fix #101 

**How to test**:
1. Run docker-compose up and make sure the contains run without errors

**Review:**
- [x] code approved by AJ
- [x] tests executed by CR

Minor version PR!
