### PR TITLE
Fix path to relevant coverage files in coveralls step of actions

### DIFF
--- a/.github/workflows/tests_and_coverage.yml
+++ b/.github/workflows/tests_and_coverage.yml
@@ -21,7 +21,7 @@ jobs:
       - name: Test with pytest & Coveralls
         run: |
           pip install -r requirements-dev.txt
-          pytest --cov=./
+          pytest --cov=./mutacc
           coveralls
         env:
           GITHUB: 1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ All notable changes to this project will be documented in this file.
 - Badge on Readme page
 - GitHub action to push the right image to Docker Hub
 - Replaced deprecated `pkg_resources` lib with `importlib_resources`
+- Path to app in tests_and_coverage.yml, coveralls step
 
 ## [1.6.3]
 ### Fixed


### PR DESCRIPTION
Fix attempt for #80

Real master branch coverage is 89% but coveralls shows 0%. 

**How to test**:
1. Merge and see how it goes on coveralls - coverage on master is already broken so it's worth an attempt

**Expected outcome**:
`mutacc` should be providing you with a progress report of your coffee making. The coffee machine should not be leaking.
Take a screenshot and attach or copy/paste the output.

**Review:**
- [ ] code approved by
- [x] tests executed by GitHub actions


Path release PR
