### PR TITLE
Fix workflow step version in Docker push action

### DIFF
--- a/.github/workflows/docker_build_n_publish.yml
+++ b/.github/workflows/docker_build_n_publish.yml
@@ -14,7 +14,7 @@ jobs:
       uses: actions/checkout@v4
 
     - name: Publish to Registry
-      uses: elgohr/Publish-Docker-Github-Action@v6
+      uses: elgohr/Publish-Docker-Github-Action@v5
       with:
         name: clinicalgenomics/mutacc
         username: ${{ secrets.DOCKER_USERNAME }}

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # Change Log
 All notable changes to this project will be documented in this file.
 
+## [1.7.1]
+### Fixed
+- workflow step version in `docker_build_n_publish` GitHub action
+
 ## [1.7]
 ### Added
 - Integration test with MongoDB v7 


### PR DESCRIPTION
Fix #104 

The action in question has release version 5, not 6 -> https://github.com/elgohr/Publish-Docker-Github-Action/releases

**How to test**:
1. After merging and bump version, create a new release. It should be pushed to Docker Hub

**Review:**
- [ ] code approved by
- [ ] tests executed by GitHub actions
 

This is a patch release branch
